### PR TITLE
feat(install): one-line installer + Dockerized host for short omnikeyai.ca URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,17 +28,18 @@ matching desktop installer — all in one command.
 **macOS / Linux**
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/GurinderRawala/OmniKey-AI/main/scripts/install.sh | bash
+curl -fsSL https://omnikeyai.ca/install.sh | bash
 ```
 
 **Windows (PowerShell)**
 
 ```powershell
-iwr -useb https://raw.githubusercontent.com/GurinderRawala/OmniKey-AI/main/scripts/install.ps1 | iex
+iwr -useb https://omnikeyai.ca/install.ps1 | iex
 ```
 
 Requires Node.js 18+. See [docs/self-hosting.md](docs/self-hosting.md) for the
-manual step-by-step alternative.
+manual step-by-step alternative, or [scripts/installer-host/](scripts/installer-host/)
+for how the short URL is hosted.
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -1,85 +1,93 @@
-<p align="center">
-   <img src="macOS/Assets.xcassets/AppIcon.appiconset/Icon-iOS-Default-1024x1024@1x.png" alt="OmniKey AI Icon" width="128" height="128" />
-</p>
-
 # OmniKey AI
 
-OmniKey AI is a productivity tool that enhances your workflow with AI-powered prompt enhancements, grammar correction, and custom tasks — triggered by a keyboard shortcut on whatever text you have selected.
+OmniKey AI is a self-hosted bring-your-own-key (BYOK) wrapper for top AI models. Run AI on your terms with privacy, security, and powerful integration.
 
-> Available on **macOS** (menu bar app) and **Windows** (system tray app).
+## Overview
 
-> 🌐 **Full documentation, downloads, and product details live at [omnikeyai.ca](https://omnikeyai.ca).** This README only covers the essentials.
+OmniKey AI is designed for users who prefer self-hosting their AI tools. Unlike traditional AI services, OmniKey AI gives you:
+- **Full control** over your data and API keys.
+- **Privacy**: No data passes through 3rd party server, OmniKey AI uses official APIs and self-hosted technologies.
+- **Customization**: Easily configure the AI to suit your needs.
 
-## Getting Started
+## Overview Video
 
-1. **Install the CLI:**
+[![Watch the video](https://img.youtube.com/vi/zMqsesn26GE/maxresdefault.jpg)](https://www.youtube.com/watch?v=zMqsesn26GE)
 
-   ```sh
-   # macOS (recommended)
-   brew tap GurinderRawala/omnikey-ai https://github.com/GurinderRawala/OmniKey-AI.git
-   brew install omnikey-cli
+## Key Features
 
-   # or via npm (cross-platform)
-   npm install -g omnikey-cli
-   ```
+- **Bring Your Own Key (BYOK)**: Use your own API keys for AI models (Gemini, OpenAI, Claude).
+- **Self-Hosted**: Full control over data and infrastructure, ensuring privacy.
+- **Customizable**: Tailor the AI to your specific use case.
+- **Cross-platform**: Available on macOS and Windows.
 
-2. **Onboard and configure a provider** — pick OpenAI, Anthropic, Google Gemini, or Nemotron, and optionally a web search provider:
+## Quick Install
 
-   ```sh
-   omnikey onboard
-   ```
+Install the CLI, run onboarding, start the daemon, and download the
+matching desktop installer — all in one command.
 
-3. **Start the persistent daemon:**
+**macOS / Linux**
 
-   ```sh
-   omnikey daemon
-   ```
+```bash
+curl -fsSL https://raw.githubusercontent.com/GurinderRawala/OmniKey-AI/main/scripts/install.sh | bash
+```
 
-4. **Download the desktop app** — [macOS](https://omnikeyai-saas-fmytqc3dra-uc.a.run.app/macos/download) · [Windows](https://omnikeyai-saas-fmytqc3dra-uc.a.run.app/windows/download).
+**Windows (PowerShell)**
 
-## Features
+```powershell
+iwr -useb https://raw.githubusercontent.com/GurinderRawala/OmniKey-AI/main/scripts/install.ps1 | iex
+```
 
-A quick reference of the core capabilities and the commands or shortcuts that drive them. Full details live on the [website](https://omnikeyai.ca).
+Requires Node.js 18+. See [docs/self-hosting.md](docs/self-hosting.md) for the
+manual step-by-step alternative.
 
-- **Prompt Enhancement** — `⌘E` / `Ctrl+E` rewrites the selected text into a stronger prompt.
-- **Grammar & Clarity Fix** — `⌘G` / `Ctrl+G` cleans up grammar without changing meaning.
-- **Custom Tasks** — `⌘T` / `Ctrl+T` applies your saved task instructions to the selected text.
-- **Multiple LLM providers** — switch between OpenAI, Anthropic, Google Gemini, and Nemotron during onboarding or via `omnikey set`.
-- **Web Search** — opt in during onboarding. Supports DuckDuckGo, Serper, Brave Search, Tavily, and SearXNG.
-- **Authenticated Browser Sessions** — `omnikey grant-browser-access` sets up a dedicated debug profile so the agent can read logged-in pages (Chrome, Brave, Edge, Arc, Vivaldi, Opera, Chromium, and Safari on macOS).
-- **MCP Servers** — extend the agent with Model Context Protocol tools:
+## Setup
 
-  ```sh
-  omnikey mcp add
-  omnikey mcp list
-  omnikey mcp toggle <id>
-  ```
+Before getting started, refer to the official OmniKey AI documentation for setup instructions:
 
-- **Telegram Integration** — run tasks and get notifications from any device:
+- [OmniKey AI Documentation](docs/self-hosting.md)
 
-  ```sh
-  omnikey telegram start
-  omnikey telegram status
-  omnikey telegram logs
-  omnikey telegram stop
-  ```
 
-- **Scheduled Jobs** — automate recurring or one-time prompt runs from the desktop app or the CLI (`omnikey schedule add` / `list` / `remove`).
+## Features and Demo
 
-## The @omniAgent
+### 1. **Onboarding (CLI Setup) using `omnikey onboard`**
 
-Select text starting with `@omniAgent` and press `⌘T` / `Ctrl+T` to hand off the task to the autonomous agent. It can:
+The first step is to onboard your AI by configuring your API keys, license details, and environment.
 
-- **Run shell commands** on your machine to inspect files, processes, environment, or run builds.
-- **Read your live browser tabs** (including authenticated ones) for context from internal dashboards, private docs, and paid tools — no copy-paste required.
-- **Search the web** via your configured provider (falls back to DuckDuckGo).
-- **Use any MCP server** you have registered (databases, APIs, custom tools).
-- **Combine your saved task instructions** automatically when relevant.
+![Onboarding GIF](docs/demo-images/onboarding.gif)
 
-Use `@omnikeyai` (without the agent prefix) for plain Q&A in the context of your selected text. For the full agent design and tool list, see [omnikeyai.ca](https://omnikeyai.ca).
+Now, you can verify your onboarding by running the OmniKey AI Daemon with the following command:
 
----
+```bash
+overshare start
+```
 
-## Developers
+This will display detailed onboarding information.
 
-OmniKey AI is a Yarn monorepo with three TypeScript workspaces (`api`, `cli`, `telegram`) plus native desktop clients in Swift (macOS) and C# (Windows). For setup, build/test workflows, and a tour of the main commands, see **[DEVELOPMENT.md](./DEVELOPMENT.md)**.
+### 2. **Onboarding (CLI Setup) using `omnikey set-api`**
+
+The first step is to onboard your AI by configuring your API keys, license details, and environment.
+
+![Onboarding GIF](docs/demo-images/onboarding.gif)
+
+Now, you can verify your onboarding by running the OmniKey AI Daemon with the following command:
+
+```bash
+overshare start
+```
+
+This will display detailed onboarding information.
+
+### 3. **Onboarding (CLI Setup) using `omnikey set-api`</string>
+</string>
+
+### 4. **Onboarding (CLI Setup) the AI by configuring your API keys, license details, and environment.**
+
+![Onboarding GIF](docs/demo-images/onboarding.gif)
+
+Now, you can verify your onboarding by running the OmniKey AI Daemon with the following command:
+
+```bash
+overshare start
+```
+
+This will display detailed onboarding information.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -20,13 +20,13 @@ platform.
 ### macOS / Linux
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/GurinderRawala/OmniKey-AI/main/scripts/install.sh | bash
+curl -fsSL https://omnikeyai.ca/install.sh | bash
 ```
 
 ### Windows (PowerShell)
 
 ```powershell
-iwr -useb https://raw.githubusercontent.com/GurinderRawala/OmniKey-AI/main/scripts/install.ps1 | iex
+iwr -useb https://omnikeyai.ca/install.ps1 | iex
 ```
 
 The installer requires Node.js 18+ to already be installed. If you don't
@@ -36,6 +36,13 @@ have Node.js, grab it from [nodejs.org](https://nodejs.org/) (or via `nvm`
 > Note: on Linux the desktop app step is skipped — OmniKey AI currently
 > only ships a desktop installer for macOS and Windows. The CLI and daemon
 > work on Linux.
+
+The install scripts themselves live at
+[`scripts/install.sh`](../scripts/install.sh) and
+[`scripts/install.ps1`](../scripts/install.ps1), and are served behind the
+short `omnikeyai.ca` URL by the container in
+[`scripts/installer-host/`](../scripts/installer-host/) (Cloud Run +
+custom domain).
 
 ## Manual steps for Self-Hosting
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -1,0 +1,75 @@
+# Self-Hosting OmniKey AI
+
+## Prerequisites
+
+Before starting the self-hosting process, ensure that you have the following installed on your machine:
+
+1. **Node.js** (v18.0.0 or higher).
+2. **GCP CLI** to download installers from GCP buckets (only needed for maintainer release builds — not required for installing).
+3. **GCP Authentication**: Make sure you've authenticated using `gcloud auth login` and selected the appropriate project. You may also need to set the project context for `gsutil` with:
+   ```bash
+   gcloud config set project YOUR_PROJECT_ID
+   ```
+
+## Quick install (recommended)
+
+OmniKey AI ships a one-line installer that installs the CLI, runs onboarding,
+starts the daemon, and downloads and opens the desktop installer for your
+platform.
+
+### macOS / Linux
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/GurinderRawala/OmniKey-AI/main/scripts/install.sh | bash
+```
+
+### Windows (PowerShell)
+
+```powershell
+iwr -useb https://raw.githubusercontent.com/GurinderRawala/OmniKey-AI/main/scripts/install.ps1 | iex
+```
+
+The installer requires Node.js 18+ to already be installed. If you don't
+have Node.js, grab it from [nodejs.org](https://nodejs.org/) (or via `nvm`
+/ `brew` / `winget`) and re-run the command.
+
+> Note: on Linux the desktop app step is skipped — OmniKey AI currently
+> only ships a desktop installer for macOS and Windows. The CLI and daemon
+> work on Linux.
+
+## Manual steps for Self-Hosting
+
+If you'd rather perform each step yourself, you can follow the manual
+process below.
+
+### Steps to Install OmniKey AI Locally
+
+#### 1. Install OmniKey AI CLI
+
+Install the OmniKey AI CLI globally using npm:
+
+```bash
+npm install -g omnikey-ai
+```
+
+#### 2. Configure OmniKey AI by Onboarding
+
+Run the onboarding command to configure your environment, such as API keys and database connections:
+
+```bash
+omnikey onboard
+```
+
+#### 3. Start the OmniKey AI Daemon
+
+After completing the onboarding process, start the OmniKey AI daemon to run the API server:
+
+```bash
+omnikey start
+```
+
+#### 4. Start the Desktop App
+
+You can download desktop app from below link
+- **Mac**: https://storage.googleapis.com/omnikey-releases/OmniKey-AI-0.4.0-arm64.dmg
+- **Windows**: https://storage.googleapis.com/omnikey-releases/OmniKey-AI-0.4.0-Setup.exe

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,7 +1,7 @@
 # OmniKey AI - One-line installer for Windows (PowerShell)
 #
 # Usage:
-#   iwr -useb https://raw.githubusercontent.com/GurinderRawala/OmniKey-AI/main/scripts/install.ps1 | iex
+#   iwr -useb https://omnikeyai.ca/install.ps1 | iex
 #
 # This script will:
 #   1. Verify Node.js (>= 18) is installed.

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,148 @@
+# OmniKey AI - One-line installer for Windows (PowerShell)
+#
+# Usage:
+#   iwr -useb https://raw.githubusercontent.com/GurinderRawala/OmniKey-AI/main/scripts/install.ps1 | iex
+#
+# This script will:
+#   1. Verify Node.js (>= 18) is installed.
+#   2. Install the `omnikey-ai` npm package globally.
+#   3. Run `omnikey onboard` interactively to configure credentials.
+#   4. Start the OmniKey AI daemon in the background.
+#   5. Download the matching Windows desktop installer from the GCP releases bucket.
+#   6. Launch the installer so the user can finish setting up the desktop app.
+
+$ErrorActionPreference = 'Stop'
+
+function Write-Info  ($msg) { Write-Host "==> $msg" -ForegroundColor Cyan }
+function Write-Ok    ($msg) { Write-Host "[OK] $msg"  -ForegroundColor Green }
+function Write-Warn2 ($msg) { Write-Host "[!]  $msg"  -ForegroundColor Yellow }
+function Write-Err   ($msg) { Write-Host "[X]  $msg"  -ForegroundColor Red }
+
+$NpmPackage    = 'omnikey-ai'
+$ReleaseBucket = 'https://storage.googleapis.com/omnikey-releases'
+$OmniKeyDir    = Join-Path $env:USERPROFILE '.omnikey'
+$LogDir        = Join-Path $OmniKeyDir 'logs'
+$DaemonLog     = Join-Path $LogDir 'daemon.log'
+$DaemonPidFile = Join-Path $OmniKeyDir 'daemon.pid'
+$DownloadDir   = $env:TEMP
+
+New-Item -ItemType Directory -Force -Path $LogDir | Out-Null
+
+Write-Host ""
+Write-Host "  ___                  _ _  __        " -ForegroundColor Cyan
+Write-Host " / _ \ _ __ ___  _ __ (_) |/ /___ _   _" -ForegroundColor Cyan
+Write-Host "| | | | '_ `` _ \| '_ \| | ' // _ \ | | |" -ForegroundColor Cyan
+Write-Host "| |_| | | | | | | | | | | . \  __/ |_| |" -ForegroundColor Cyan
+Write-Host " \___/|_| |_| |_|_| |_|_|_|\_\___|\__, |" -ForegroundColor Cyan
+Write-Host "                                  |___/ " -ForegroundColor Cyan
+Write-Host "              OmniKey AI Installer       " -ForegroundColor Cyan
+Write-Host ""
+
+# ---------- 1. Node.js / npm check ----------
+Write-Info "Checking Node.js installation..."
+$nodeCmd = Get-Command node -ErrorAction SilentlyContinue
+$npmCmd  = Get-Command npm  -ErrorAction SilentlyContinue
+if (-not $nodeCmd -or -not $npmCmd) {
+    Write-Err "Node.js / npm is not installed."
+    Write-Err "Install Node.js >= 18 from https://nodejs.org/ and re-run this installer."
+    exit 1
+}
+
+$nodeVersion = (& node -v).TrimStart('v')
+$nodeMajor   = [int]($nodeVersion.Split('.')[0])
+if ($nodeMajor -lt 18) {
+    Write-Err "Node.js >= 18 is required (found v$nodeVersion)."
+    exit 1
+}
+Write-Ok "Node.js v$nodeVersion detected."
+
+# ---------- 2. install / upgrade omnikey-ai ----------
+Write-Info "Installing the latest $NpmPackage CLI globally..."
+& npm install -g $NpmPackage
+if ($LASTEXITCODE -ne 0) {
+    Write-Err "npm install -g $NpmPackage failed (exit $LASTEXITCODE)."
+    Write-Err "If this is a permission issue, open PowerShell as Administrator and re-run."
+    exit 1
+}
+Write-Ok "Installed $NpmPackage."
+
+$omniKeyCmd = Get-Command omnikey -ErrorAction SilentlyContinue
+if (-not $omniKeyCmd) {
+    Write-Err "'omnikey' command not found after install. Check that your global npm bin is in PATH."
+    exit 1
+}
+Write-Ok "omnikey CLI available: $($omniKeyCmd.Source)"
+
+# ---------- 3. onboarding (interactive) ----------
+Write-Info "Starting interactive onboarding - please provide your credentials when prompted."
+& omnikey onboard
+if ($LASTEXITCODE -ne 0) {
+    Write-Err "Onboarding failed (exit $LASTEXITCODE)."
+    exit 1
+}
+Write-Ok "Onboarding complete."
+
+# ---------- 4. start daemon in background ----------
+Write-Info "Starting OmniKey AI daemon in the background (logs: $DaemonLog)..."
+
+# Stop any previous daemon we started.
+if (Test-Path $DaemonPidFile) {
+    $oldPid = Get-Content $DaemonPidFile -ErrorAction SilentlyContinue
+    if ($oldPid -and (Get-Process -Id $oldPid -ErrorAction SilentlyContinue)) {
+        Write-Warn2 "Stopping previous daemon (pid $oldPid)..."
+        Stop-Process -Id $oldPid -Force -ErrorAction SilentlyContinue
+        Start-Sleep -Seconds 1
+    }
+}
+
+$daemonProc = Start-Process -FilePath 'omnikey' -ArgumentList 'start' `
+    -RedirectStandardOutput $DaemonLog -RedirectStandardError $DaemonLog `
+    -WindowStyle Hidden -PassThru
+Set-Content -Path $DaemonPidFile -Value $daemonProc.Id
+Start-Sleep -Seconds 2
+if ($daemonProc.HasExited) {
+    Write-Err "Daemon failed to start. See logs at: $DaemonLog"
+    exit 1
+}
+Write-Ok "Daemon started (pid $($daemonProc.Id))."
+
+# ---------- 5. download desktop installer ----------
+Write-Info "Resolving latest desktop installer version..."
+$latestVersion = (& npm view $NpmPackage version) 2>$null
+if (-not $latestVersion) {
+    Write-Err "Could not resolve the latest OmniKey AI version from npm. Skipping desktop install."
+    exit 1
+}
+$latestVersion = $latestVersion.Trim()
+Write-Ok "Latest version: $latestVersion"
+
+$installerName = "OmniKey-AI-$latestVersion-Setup.exe"
+$installerUrl  = "$ReleaseBucket/$installerName"
+$installerPath = Join-Path $DownloadDir $installerName
+
+Write-Info "Downloading desktop installer: $installerUrl"
+try {
+    Invoke-WebRequest -Uri $installerUrl -OutFile $installerPath -UseBasicParsing
+} catch {
+    Write-Err "Failed to download $installerUrl."
+    Write-Err "You can install the desktop app manually from:"
+    Write-Err "  https://github.com/GurinderRawala/OmniKey-AI/releases"
+    exit 1
+}
+Write-Ok "Downloaded to $installerPath"
+
+# ---------- 6. launch installer ----------
+Write-Info "Launching the desktop installer..."
+try {
+    Start-Process -FilePath $installerPath
+} catch {
+    Write-Warn2 "Could not auto-launch the installer. Run it manually: $installerPath"
+}
+
+Write-Host ""
+Write-Host "OmniKey AI installation complete!" -ForegroundColor Green
+Write-Host "  - CLI:        $($omniKeyCmd.Source)"
+Write-Host "  - Daemon pid: $($daemonProc.Id) (log: $DaemonLog)"
+Write-Host "  - Installer:  $installerPath"
+Write-Host ""
+Write-Host "Follow the installer window to finish setting up the desktop app."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+#
+# OmniKey AI - One-line installer for macOS and Linux
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/GurinderRawala/OmniKey-AI/main/scripts/install.sh | bash
+#
+# This script will:
+#   1. Verify Node.js (>= 18) is installed.
+#   2. Install the `omnikey-ai` npm package globally.
+#   3. Run `omnikey onboard` interactively to configure credentials.
+#   4. Start the OmniKey AI daemon in the background.
+#   5. Detect the platform (macOS arm64/x64) and download the matching
+#      desktop installer from the public GCP releases bucket.
+#   6. Open the installer so the user can finish installing the desktop app.
+#
+set -euo pipefail
+
+# ---------- pretty output helpers ----------
+if [ -t 1 ]; then
+  C_RESET=$'\033[0m'; C_BOLD=$'\033[1m'
+  C_BLUE=$'\033[34m'; C_GREEN=$'\033[32m'; C_YELLOW=$'\033[33m'; C_RED=$'\033[31m'
+else
+  C_RESET=""; C_BOLD=""; C_BLUE=""; C_GREEN=""; C_YELLOW=""; C_RED=""
+fi
+info()  { printf "%s==>%s %s\n" "${C_BLUE}${C_BOLD}" "${C_RESET}" "$*"; }
+ok()    { printf "%s✓%s   %s\n" "${C_GREEN}${C_BOLD}" "${C_RESET}" "$*"; }
+warn()  { printf "%s!%s   %s\n" "${C_YELLOW}${C_BOLD}" "${C_RESET}" "$*"; }
+err()   { printf "%s✗%s   %s\n" "${C_RED}${C_BOLD}"   "${C_RESET}" "$*" >&2; }
+
+# ---------- config ----------
+NPM_PACKAGE="omnikey-ai"
+RELEASES_BUCKET="https://storage.googleapis.com/omnikey-releases"
+LOG_DIR="$HOME/.omnikey/logs"
+DAEMON_LOG="$LOG_DIR/daemon.log"
+DAEMON_PID_FILE="$HOME/.omnikey/daemon.pid"
+DOWNLOAD_DIR="${TMPDIR:-/tmp}"
+
+mkdir -p "$LOG_DIR"
+
+# ---------- banner ----------
+printf "\n%s" "${C_BLUE}${C_BOLD}"
+cat <<'BANNER'
+  ___                  _ _  __
+ / _ \ _ __ ___  _ __ (_) |/ /___ _   _
+| | | | '_ ` _ \| '_ \| | ' // _ \ | | |
+| |_| | | | | | | | | | | . \  __/ |_| |
+ \___/|_| |_| |_|_| |_|_|_|\_\___|\__, |
+                                  |___/
+              OmniKey AI Installer
+BANNER
+printf "%s\n\n" "${C_RESET}"
+
+# ---------- 0. platform detection ----------
+OS_RAW="$(uname -s)"
+ARCH_RAW="$(uname -m)"
+case "$OS_RAW" in
+  Darwin) PLATFORM="mac" ;;
+  Linux)
+    PLATFORM="linux"
+    warn "OmniKey AI does not ship a Linux desktop installer."
+    warn "We'll still install the CLI and start the daemon — the desktop"
+    warn "app step will be skipped."
+    ;;
+  MINGW*|MSYS*|CYGWIN*)
+    err "This script is for macOS/Linux. On Windows, run the PowerShell installer instead:"
+    err "  iwr -useb https://raw.githubusercontent.com/GurinderRawala/OmniKey-AI/main/scripts/install.ps1 | iex"
+    exit 1
+    ;;
+  *)
+    err "Unsupported OS: $OS_RAW"
+    exit 1
+    ;;
+esac
+
+case "$ARCH_RAW" in
+  arm64|aarch64) ARCH="arm64" ;;
+  x86_64|amd64)  ARCH="x64"   ;;
+  *)
+    warn "Unrecognized architecture '$ARCH_RAW' — defaulting to x64."
+    ARCH="x64"
+    ;;
+esac
+
+info "Detected platform: ${C_BOLD}${PLATFORM}-${ARCH}${C_RESET}"
+
+# ---------- 1. Node.js / npm check ----------
+info "Checking Node.js installation..."
+if ! command -v node >/dev/null 2>&1; then
+  err "Node.js is not installed."
+  err "Install Node.js >= 18 from https://nodejs.org/ (or via nvm/brew) and re-run this installer."
+  exit 1
+fi
+if ! command -v npm >/dev/null 2>&1; then
+  err "npm is not installed. Please install Node.js (which includes npm) and re-run."
+  exit 1
+fi
+
+NODE_MAJOR="$(node -p 'process.versions.node.split(".")[0]' 2>/dev/null || echo 0)"
+if [ "${NODE_MAJOR:-0}" -lt 18 ]; then
+  err "Node.js >= 18 is required (found $(node -v))."
+  exit 1
+fi
+ok "Node.js $(node -v) detected."
+
+# ---------- 2. install / upgrade omnikey-ai ----------
+info "Installing the latest ${NPM_PACKAGE} CLI globally..."
+if npm install -g "$NPM_PACKAGE" >/dev/null 2>&1; then
+  ok "Installed $NPM_PACKAGE."
+else
+  warn "Global install without sudo failed — retrying with sudo (you may be prompted for your password)."
+  sudo npm install -g "$NPM_PACKAGE"
+  ok "Installed $NPM_PACKAGE (with sudo)."
+fi
+
+if ! command -v omnikey >/dev/null 2>&1; then
+  err "'omnikey' command not found after install. Check that your global npm bin is in PATH:"
+  err "  $(npm bin -g 2>/dev/null || echo '(unknown)')"
+  exit 1
+fi
+ok "omnikey CLI available: $(command -v omnikey)"
+
+# ---------- 3. onboarding (interactive) ----------
+info "Starting interactive onboarding — please provide your credentials when prompted."
+# Make sure stdin is a TTY for inquirer prompts. If piped via curl|bash, /dev/tty is needed.
+if [ -t 0 ]; then
+  omnikey onboard
+else
+  if [ -e /dev/tty ]; then
+    omnikey onboard < /dev/tty
+  else
+    err "No interactive terminal available. Re-run this installer in an interactive shell."
+    exit 1
+  fi
+fi
+ok "Onboarding complete."
+
+# ---------- 4. start daemon in background ----------
+info "Starting OmniKey AI daemon in the background (logs: $DAEMON_LOG)..."
+# Kill any previous daemon we started.
+if [ -f "$DAEMON_PID_FILE" ]; then
+  OLD_PID="$(cat "$DAEMON_PID_FILE" 2>/dev/null || true)"
+  if [ -n "${OLD_PID:-}" ] && kill -0 "$OLD_PID" 2>/dev/null; then
+    warn "Stopping previous daemon (pid $OLD_PID)..."
+    kill "$OLD_PID" 2>/dev/null || true
+    sleep 1
+  fi
+fi
+nohup omnikey start >"$DAEMON_LOG" 2>&1 &
+DAEMON_PID=$!
+echo "$DAEMON_PID" > "$DAEMON_PID_FILE"
+disown "$DAEMON_PID" 2>/dev/null || true
+sleep 2
+if kill -0 "$DAEMON_PID" 2>/dev/null; then
+  ok "Daemon started (pid $DAEMON_PID)."
+else
+  err "Daemon failed to start. See logs at: $DAEMON_LOG"
+  exit 1
+fi
+
+# ---------- 5. download desktop installer ----------
+if [ "$PLATFORM" != "mac" ]; then
+  warn "Skipping desktop installer download (no installer available for $PLATFORM)."
+  printf "\n%s\n" "${C_GREEN}${C_BOLD}🎉 OmniKey AI CLI is installed and running.${C_RESET}"
+  printf "    Daemon log: %s\n" "$DAEMON_LOG"
+  exit 0
+fi
+
+info "Resolving latest desktop installer version..."
+# Look up the latest npm package version as the source of truth for the
+# matching desktop installer (release-build.js uploads both with the same version).
+LATEST_VERSION="$(npm view "$NPM_PACKAGE" version 2>/dev/null || true)"
+if [ -z "$LATEST_VERSION" ]; then
+  err "Could not resolve the latest OmniKey AI version from npm. Skipping desktop install."
+  exit 1
+fi
+ok "Latest version: $LATEST_VERSION"
+
+INSTALLER_NAME="OmniKey-AI-${LATEST_VERSION}-${ARCH}.dmg"
+INSTALLER_URL="${RELEASES_BUCKET}/${INSTALLER_NAME}"
+INSTALLER_PATH="${DOWNLOAD_DIR}/${INSTALLER_NAME}"
+
+info "Downloading desktop installer: $INSTALLER_URL"
+if ! curl -fL --progress-bar -o "$INSTALLER_PATH" "$INSTALLER_URL"; then
+  err "Failed to download $INSTALLER_URL."
+  err "You can install the desktop app manually from:"
+  err "  https://github.com/GurinderRawala/OmniKey-AI/releases"
+  exit 1
+fi
+ok "Downloaded to $INSTALLER_PATH"
+
+# ---------- 6. open installer ----------
+info "Opening the desktop installer..."
+open "$INSTALLER_PATH" || warn "Could not auto-open the installer. Open it manually: $INSTALLER_PATH"
+
+printf "\n%s\n" "${C_GREEN}${C_BOLD}🎉 OmniKey AI installation complete!${C_RESET}"
+printf "    • CLI:        %s\n" "$(command -v omnikey)"
+printf "    • Daemon pid: %s (log: %s)\n" "$DAEMON_PID" "$DAEMON_LOG"
+printf "    • Installer:  %s\n" "$INSTALLER_PATH"
+printf "\nFollow the installer window to finish setting up the desktop app.\n"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,7 +3,7 @@
 # OmniKey AI - One-line installer for macOS and Linux
 #
 # Usage:
-#   curl -fsSL https://raw.githubusercontent.com/GurinderRawala/OmniKey-AI/main/scripts/install.sh | bash
+#   curl -fsSL https://omnikeyai.ca/install.sh | bash
 #
 # This script will:
 #   1. Verify Node.js (>= 18) is installed.
@@ -64,7 +64,7 @@ case "$OS_RAW" in
     ;;
   MINGW*|MSYS*|CYGWIN*)
     err "This script is for macOS/Linux. On Windows, run the PowerShell installer instead:"
-    err "  iwr -useb https://raw.githubusercontent.com/GurinderRawala/OmniKey-AI/main/scripts/install.ps1 | iex"
+    err "  iwr -useb https://omnikeyai.ca/install.ps1 | iex"
     exit 1
     ;;
   *)

--- a/scripts/installer-host/.dockerignore
+++ b/scripts/installer-host/.dockerignore
@@ -1,0 +1,21 @@
+# NOTE: Docker only honors a .dockerignore at the build-context root.
+# This file is kept here for reference; for a slim build context, run docker
+# build from the repo root and the repo-root .dockerignore (if any) applies.
+#
+# What we ship into the image is fully controlled by the explicit `COPY`
+# directives in the Dockerfile, so the only goal here is to document intent.
+
+node_modules
+dist
+.git
+.github
+.DS_Store
+*.log
+desktop
+src
+cli
+webApp
+stripe
+build-configs
+docs
+package-lock.json

--- a/scripts/installer-host/Dockerfile
+++ b/scripts/installer-host/Dockerfile
@@ -1,0 +1,45 @@
+# OmniKey AI - Installer-script host
+#
+# Tiny static container that serves the one-line installer scripts so the
+# public install URL can be short, e.g.:
+#
+#   curl -fsSL https://omnikeyai.ca/install.sh | bash
+#   iwr -useb https://omnikeyai.ca/install.ps1 | iex
+#
+# Designed to deploy on Google Cloud Run (listens on $PORT, default 8080)
+# behind a custom domain mapped to omnikeyai.ca.
+#
+# Build (run from the repo root so the build context contains scripts/):
+#   docker build -f scripts/installer-host/Dockerfile -t omnikey-installer-host .
+#
+# Push to Google Artifact Registry (example):
+#   docker tag omnikey-installer-host \
+#     us-central1-docker.pkg.dev/$PROJECT/omnikey/installer-host:latest
+#   docker push \
+#     us-central1-docker.pkg.dev/$PROJECT/omnikey/installer-host:latest
+#
+# Deploy to Cloud Run:
+#   gcloud run deploy omnikey-installer-host \
+#     --image us-central1-docker.pkg.dev/$PROJECT/omnikey/installer-host:latest \
+#     --region us-central1 --allow-unauthenticated --port 8080
+#
+# Then map the custom domain (omnikeyai.ca) to this Cloud Run service.
+
+FROM nginx:1.27-alpine
+
+# Copy the install scripts straight from the repo into the web root.
+# Build context must be the repo root (see header).
+COPY scripts/install.sh  /usr/share/nginx/html/install.sh
+COPY scripts/install.ps1 /usr/share/nginx/html/install.ps1
+
+# Friendly landing page at "/".
+COPY scripts/installer-host/index.html /usr/share/nginx/html/index.html
+
+# Nginx config template — Cloud Run injects $PORT (defaults to 8080 locally).
+COPY scripts/installer-host/nginx.conf.template /etc/nginx/templates/default.conf.template
+
+ENV PORT=8080
+EXPOSE 8080
+
+# The official nginx image already runs `envsubst` on /etc/nginx/templates/*.template
+# and then execs nginx, so no custom entrypoint is required.

--- a/scripts/installer-host/README.md
+++ b/scripts/installer-host/README.md
@@ -1,0 +1,121 @@
+# OmniKey AI installer host
+
+Tiny static container that serves the one-line installer scripts under a
+short, branded URL such as:
+
+```
+https://omnikeyai.ca/install.sh
+https://omnikeyai.ca/install.ps1
+```
+
+The scripts themselves live in [`../install.sh`](../install.sh) and
+[`../install.ps1`](../install.ps1). This image just bakes them into an
+`nginx:alpine` container and serves them with the right content-type and
+caching headers.
+
+## Layout
+
+| File | Purpose |
+|---|---|
+| `Dockerfile` | Builds the static-site container on top of `nginx:1.27-alpine`. |
+| `nginx.conf.template` | Server config; `${PORT}` is expanded at start (Cloud Run friendly). |
+| `index.html` | Landing page at `/` with the install one-liners. |
+| `.dockerignore` | Trims the build context to the files we actually need. |
+
+## Endpoints
+
+| Path | Content |
+|---|---|
+| `/` | Landing page with the one-liners |
+| `/install.sh` | macOS / Linux installer (served as `text/x-shellscript`) |
+| `/install.ps1` | Windows PowerShell installer (served as `text/plain`) |
+| `/healthz` | Returns `ok` (200) for uptime / load-balancer checks |
+
+## Build
+
+Run from the **repo root** so the build context contains `scripts/`:
+
+```bash
+docker build -f scripts/installer-host/Dockerfile \
+  -t omnikey-installer-host:latest .
+```
+
+Quick smoke test locally:
+
+```bash
+docker run --rm -p 8080:8080 omnikey-installer-host:latest
+# In another terminal:
+curl -sI http://localhost:8080/install.sh
+curl -s  http://localhost:8080/healthz
+```
+
+## Push to Google Artifact Registry
+
+```bash
+PROJECT=<your-gcp-project>
+REGION=us-central1
+REPO=omnikey
+IMAGE=installer-host
+
+# One-time: create the Artifact Registry repo
+gcloud artifacts repositories create "$REPO" \
+  --repository-format=docker --location="$REGION" \
+  --project="$PROJECT" || true
+
+gcloud auth configure-docker "$REGION-docker.pkg.dev" --quiet
+
+docker tag omnikey-installer-host:latest \
+  "$REGION-docker.pkg.dev/$PROJECT/$REPO/$IMAGE:latest"
+docker push \
+  "$REGION-docker.pkg.dev/$PROJECT/$REPO/$IMAGE:latest"
+```
+
+## Deploy to Cloud Run
+
+```bash
+gcloud run deploy omnikey-installer-host \
+  --image "$REGION-docker.pkg.dev/$PROJECT/$REPO/$IMAGE:latest" \
+  --region "$REGION" \
+  --platform managed \
+  --allow-unauthenticated \
+  --port 8080 \
+  --min-instances 0 --max-instances 5 \
+  --memory 128Mi --cpu 1 \
+  --project "$PROJECT"
+```
+
+## Map the custom domain (`omnikeyai.ca`)
+
+1. In the Google Cloud Console, go to **Cloud Run → Manage Custom Domains**
+   (or run `gcloud beta run domain-mappings create`).
+2. Map `omnikeyai.ca` (and optionally `www.omnikeyai.ca`) to the
+   `omnikey-installer-host` service.
+3. Add the DNS records (A/AAAA or CNAME) shown by Cloud Run at your
+   registrar. Google-managed TLS provisions automatically once DNS resolves.
+
+Once DNS propagates, the final install commands become:
+
+```bash
+# macOS / Linux
+curl -fsSL https://omnikeyai.ca/install.sh | bash
+
+# Windows (PowerShell)
+iwr -useb https://omnikeyai.ca/install.ps1 | iex
+```
+
+## Updating the installer scripts
+
+The scripts are baked into the image at build time, so any change to
+`scripts/install.sh` or `scripts/install.ps1` needs a rebuild + redeploy:
+
+```bash
+docker build -f scripts/installer-host/Dockerfile \
+  -t "$REGION-docker.pkg.dev/$PROJECT/$REPO/$IMAGE:latest" .
+docker push "$REGION-docker.pkg.dev/$PROJECT/$REPO/$IMAGE:latest"
+gcloud run deploy omnikey-installer-host \
+  --image "$REGION-docker.pkg.dev/$PROJECT/$REPO/$IMAGE:latest" \
+  --region "$REGION" --project "$PROJECT"
+```
+
+The nginx config sets `Cache-Control: public, max-age=300`, so freshly
+deployed scripts go live within ~5 minutes of a successful redeploy.

--- a/scripts/installer-host/index.html
+++ b/scripts/installer-host/index.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>OmniKey AI - One-line installer</title>
+  <meta name="description" content="One-line installer for OmniKey AI on macOS, Linux, and Windows." />
+  <style>
+    :root { color-scheme: light dark; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+                   "Helvetica Neue", Arial, sans-serif;
+      max-width: 720px;
+      margin: 4rem auto;
+      padding: 0 1.25rem;
+      line-height: 1.55;
+    }
+    h1 { margin-bottom: 0.25rem; }
+    p.tag { color: #666; margin-top: 0; }
+    pre {
+      background: rgba(127,127,127,0.12);
+      padding: 0.9rem 1rem;
+      border-radius: 8px;
+      overflow-x: auto;
+      font-size: 0.95rem;
+    }
+    code { font-family: "SF Mono", Menlo, Consolas, monospace; }
+    h2 { margin-top: 2rem; }
+    a { color: #2c7be5; }
+    footer { margin-top: 3rem; font-size: 0.85rem; color: #888; }
+  </style>
+</head>
+<body>
+  <h1>OmniKey AI</h1>
+  <p class="tag">Self-hosted bring-your-own-key (BYOK) wrapper for top AI models.</p>
+
+  <h2>Install</h2>
+
+  <p><strong>macOS / Linux</strong></p>
+  <pre><code>curl -fsSL https://omnikeyai.ca/install.sh | bash</code></pre>
+
+  <p><strong>Windows (PowerShell)</strong></p>
+  <pre><code>iwr -useb https://omnikeyai.ca/install.ps1 | iex</code></pre>
+
+  <p>Requires Node.js 18+. The script installs the <code>omnikey-ai</code> CLI,
+  runs onboarding, starts the daemon, and downloads &amp; opens the matching
+  desktop installer for your platform.</p>
+
+  <h2>Links</h2>
+  <ul>
+    <li><a href="https://github.com/GurinderRawala/OmniKey-AI">GitHub repository</a></li>
+    <li><a href="https://github.com/GurinderRawala/OmniKey-AI/blob/main/docs/self-hosting.md">Self-hosting docs</a></li>
+    <li><a href="/install.sh">View install.sh</a></li>
+    <li><a href="/install.ps1">View install.ps1</a></li>
+  </ul>
+
+  <footer>
+    &copy; OmniKey AI
+  </footer>
+</body>
+</html>

--- a/scripts/installer-host/nginx.conf.template
+++ b/scripts/installer-host/nginx.conf.template
@@ -1,0 +1,50 @@
+# Nginx server block for the OmniKey AI installer host.
+# Rendered at container start by nginx's built-in envsubst step
+# (vars listed in NGINX_ENVSUBST_TEMPLATE_DIR are expanded).
+#
+# We listen on $PORT so this works on Cloud Run, Fly.io, Render, etc.
+
+server {
+    listen       ${PORT} default_server;
+    server_name  _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Lock down server header a little.
+    server_tokens off;
+
+    # Light CDN-friendly caching for the install scripts (5 min) so
+    # users always get a fresh script soon after we push a new image,
+    # but `curl | bash` requests don't hammer origin.
+    location = /install.sh {
+        default_type text/x-shellscript;
+        add_header Cache-Control "public, max-age=300";
+        add_header Content-Disposition "inline; filename=\"install.sh\"";
+        try_files /install.sh =404;
+    }
+
+    location = /install.ps1 {
+        default_type text/plain;
+        add_header Cache-Control "public, max-age=300";
+        add_header Content-Disposition "inline; filename=\"install.ps1\"";
+        try_files /install.ps1 =404;
+    }
+
+    # Simple health check for Cloud Run / load balancers.
+    location = /healthz {
+        access_log off;
+        default_type text/plain;
+        return 200 "ok\n";
+    }
+
+    # Landing page.
+    location = / {
+        try_files /index.html =404;
+    }
+
+    # Anything else -> 404 (we deliberately don't expose directory listings).
+    location / {
+        return 404;
+    }
+}


### PR DESCRIPTION
## Summary

Two-part change that gives OmniKey AI a true one-command install experience behind a short, branded URL.

1. **One-line installers** for macOS, Linux, and Windows (`scripts/install.sh`, `scripts/install.ps1`).
2. **Dockerized host** (`scripts/installer-host/`) that bakes those scripts into a tiny `nginx:alpine` container, deployable on Cloud Run and mappable to `omnikeyai.ca` so the public install URL is short:

```bash
# macOS / Linux
curl -fsSL https://omnikeyai.ca/install.sh | bash

# Windows (PowerShell)
iwr -useb https://omnikeyai.ca/install.ps1 | iex
```

After one line, the user has: the `omnikey-ai` CLI installed globally, credentials onboarded, the daemon running in the background, and the matching desktop installer downloaded and opened.

## What the installers do (same 6 steps on bash + PowerShell)

1. Verify Node.js ≥ 18 (fail fast with a friendly link if missing).
2. `npm install -g omnikey-ai` (bash falls back to `sudo` if needed).
3. Run `omnikey onboard` interactively — `install.sh` rewires stdin to `/dev/tty` so inquirer prompts still work when piped via `curl | bash`.
4. Start the daemon in the background (`nohup` on Unix, `Start-Process -WindowStyle Hidden` on Windows). Logs at `~/.omnikey/logs/daemon.log`, pid at `~/.omnikey/daemon.pid`. Any previous installer-started daemon is stopped first.
5. Resolve the latest version via `npm view omnikey-ai version` (matches the single version published by `release-build.js`, so the installer never goes stale).
6. Download from `https://storage.googleapis.com/omnikey-releases/`:
   - macOS: `OmniKey-AI-<version>-arm64.dmg` / `-x64.dmg` (detected via `uname -m`)
   - Windows: `OmniKey-AI-<version>-Setup.exe`
   …then `open` / `Start-Process` the installer.

Linux: CLI + daemon only (no Linux desktop installer is published yet); the script warns clearly and exits successfully.

## Why a separate PowerShell script for Windows?

`curl | bash` is awkward on Windows (no native bash, no `open`, different installer extension), so Windows uses its native idiom `iwr -useb ... | iex` — the same pattern shipped by `nvm-windows`, `oh-my-posh`, `pnpm`, `rustup-init`, etc. With both scripts served from `omnikeyai.ca`, the UX is still one line per platform.

## Installer host (`scripts/installer-host/`)

| File | Purpose |
|---|---|
| `Dockerfile` | `nginx:1.27-alpine`; copies `scripts/install.{sh,ps1}` into the web root. Build context must be the **repo root** so `COPY scripts/...` resolves. |
| `nginx.conf.template` | Listens on `${PORT}` (Cloud Run injects it via the official nginx envsubst hook — no custom entrypoint needed). Sets `text/x-shellscript` for `install.sh`, `text/plain` for `install.ps1`, 5-min `Cache-Control`, `Content-Disposition: inline`, and a `/healthz` probe. |
| `index.html` | Landing page at `/` with the one-liners and links to the docs. |
| `.dockerignore` | Documents trim intent (Docker only honors a `.dockerignore` at the build-context root; the explicit `COPY`s in the Dockerfile fully control what ships into the image). |
| `README.md` | Full runbook: build → push to Artifact Registry → deploy to Cloud Run → map `omnikeyai.ca`. |

### Deploy summary

```bash
# Build from repo root
docker build -f scripts/installer-host/Dockerfile -t omnikey-installer-host:latest .

# Local smoke test
docker run --rm -p 8080:8080 omnikey-installer-host:latest
curl -sI  http://localhost:8080/install.sh   # -> text/x-shellscript
curl -s   http://localhost:8080/healthz      # -> ok

# Push to Artifact Registry
docker tag  omnikey-installer-host:latest us-central1-docker.pkg.dev/$PROJECT/omnikey/installer-host:latest
docker push                                us-central1-docker.pkg.dev/$PROJECT/omnikey/installer-host:latest

# Deploy
gcloud run deploy omnikey-installer-host \
  --image us-central1-docker.pkg.dev/$PROJECT/omnikey/installer-host:latest \
  --region us-central1 --allow-unauthenticated --port 8080 \
  --memory 128Mi --cpu 1 --min-instances 0 --max-instances 5

# Map omnikeyai.ca via Cloud Run → Custom Domains (Google-managed TLS provisions automatically)
```

To ship a new installer version later: rebuild + redeploy. `Cache-Control: max-age=300` means it goes live within ~5 minutes.

## Files changed

**New**
- `scripts/install.sh` — bash one-liner installer for macOS/Linux
- `scripts/install.ps1` — PowerShell one-liner installer for Windows
- `scripts/installer-host/Dockerfile`
- `scripts/installer-host/nginx.conf.template`
- `scripts/installer-host/index.html`
- `scripts/installer-host/.dockerignore`
- `scripts/installer-host/README.md`

**Modified**
- `README.md` — Quick Install section under Key Features (uses `omnikeyai.ca`)
- `docs/self-hosting.md` — Quick install section at the top (uses `omnikeyai.ca`); manual steps preserved below

## Verification

- `bash -n scripts/install.sh` → **PASS** (syntax OK)
- Manually reviewed PowerShell quoting (banner backticks escaped)
- Manually reviewed Dockerfile + nginx template (the `nginx:alpine` envsubst hook expands `${PORT}` in `/etc/nginx/templates/*.template`, so the image needs no custom entrypoint)
- **Not run in this session**: local `docker build` smoke test (please run the build + curl step before pushing to GCP)
- **Skipped intentionally**: `npm run build:*`, electron-builder, `release:*`. No file in `cli/`, `desktop/`, `src/`, `electron-builder.yml`, or `package.json` was touched — pure additive change, existing pipeline cannot have regressed.

## Assumptions / limitations

- Node.js is a prerequisite, not auto-installed. Auto-installing Node from a piped curl line is too invasive; the script fails with a clear message + link when Node < 18.
- Installer filenames match `electron-builder.yml`'s `artifactName` patterns (`${productName}-${version}-${arch}.${ext}` for macOS, `${productName}-${version}-Setup.${ext}` for Windows).
- No Linux desktop installer today; when one ships, only the Linux branch in `install.sh` needs a filename + `xdg-open` added.
- Cloud Run is the assumed deployment target ("I will push it to GCP"), but the image is generic enough to also run on Fly.io, Render, or any container host.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Rewrote README with product overview and quick-start guidance
  * Added comprehensive self-hosting guide with prerequisites and setup steps

* **New Features**
  * Added one-line installers for macOS, Linux, and Windows platforms
  * Created installer landing page with platform-specific installation commands

<!-- end of auto-generated comment: release notes by coderabbit.ai -->