### PR TITLE
feat(settings): add Agent Access pane — terminal mode, web search, browser access

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omnikey-ai-api",
-  "version": "1.6.8",
+  "version": "1.6.9",
   "main": "dist/index.js",
   "description": "Omnikey AI backend API. Use Yarn for install/build/start.",
   "scripts": {

--- a/api/src/agent/agentServer.ts
+++ b/api/src/agent/agentServer.ts
@@ -67,6 +67,14 @@ async function runToolLoop(
   mcpDispatch: Map<string, { serverId: string; mcpToolName: string }>,
   onUsage: (result: AICompletionResult) => Promise<void>,
 ): Promise<AICompletionResult> {
+  // Tools the model is allowed to invoke on this turn. Built from the same
+  // list we hand to the AI client, so flipping `WEB_SEARCH_ENABLED` (or any
+  // future capability toggle) actually disables the tool at the execution
+  // boundary, not just at registration. Without this set, a model that
+  // already saw web_search/web_fetch on a previous turn — or one that
+  // hallucinates a tool name — could still slip a call through to
+  // executeTool(). See CodeRabbit PR #18 review.
+  const allowedToolNames = new Set(tools.map((tool) => tool.name));
   let toolIterations = 0;
   let result = initialResult;
 
@@ -164,6 +172,34 @@ async function runToolLoop(
             pendingShellScripts.set(sessionId, resolve);
           });
           return { id: tc.id, name: tc.name, result: terminalOutput };
+        }
+
+        // If the tool is not in the per-turn allowed list (e.g. the user
+        // disabled web search via Settings → Agent Access, or the model
+        // hallucinated a tool name), refuse the call instead of forwarding
+        // it to executeTool. Returning a structured error lets the model
+        // recover on its own turn without us silently running a disabled
+        // capability. See CodeRabbit PR #18 review.
+        if (!allowedToolNames.has(tc.name)) {
+          log.warn('Refusing tool call: tool is not enabled for this session', {
+            sessionId,
+            tool: tc.name,
+            allowed: Array.from(allowedToolNames),
+          });
+          send({
+            session_id: sessionId,
+            sender: 'agent',
+            content: `Tool "${tc.name}" is not enabled for this session.`,
+            is_terminal_output: false,
+            is_error: true,
+          });
+          return {
+            id: tc.id,
+            name: tc.name,
+            result:
+              `Error: Tool "${tc.name}" is not enabled for this session. ` +
+              `Available tools: ${Array.from(allowedToolNames).join(', ') || '(none)'}.`,
+          };
         }
 
         // Notify the frontend that a web tool call is about to execute.

--- a/api/src/agent/agentServer.ts
+++ b/api/src/agent/agentServer.ts
@@ -19,6 +19,7 @@ import { executeImageGenerationTool } from './imageTool';
 import {
   buildAvailableTools,
   SHELL_SCRIPT_TOOL,
+  SHELL_SCRIPT_TOOL_LIMITED,
   createUserContent,
   sendFinalAnswer,
   pushToSessionHistory,
@@ -569,7 +570,16 @@ async function runAgentTurnInternal(
   // gpt-5.5 (Responses API) already has execute_shell_script wired internally;
   // all other providers get shell_script as a native function tool so the model
   // can call it directly instead of emitting XML tags.
-  const shellTools: AITool[] = aiModel !== RESPONSES_API_MODEL ? [SHELL_SCRIPT_TOOL] : [];
+  //
+  // When the user has set TERMINAL_ACCESS=limited via Settings → Agent Access,
+  // we expose the same tool name but with a description that tells the model
+  // to stay within read-only / inspection commands. The Responses API path
+  // injects its equivalent restriction inside ai-client.ts (see
+  // shellScriptToolDescriptionForMode there).
+  const shellTool = config.terminalAccess === 'limited'
+    ? SHELL_SCRIPT_TOOL_LIMITED
+    : SHELL_SCRIPT_TOOL;
+  const shellTools: AITool[] = aiModel !== RESPONSES_API_MODEL ? [shellTool] : [];
   const tools = buildAvailableTools([...shellTools, ...mcpBundle.aiTools]);
 
   const recordUsage = async (result: AICompletionResult) => {

--- a/api/src/agent/utils.ts
+++ b/api/src/agent/utils.ts
@@ -37,6 +37,34 @@ export const SHELL_SCRIPT_TOOL: AITool = {
 };
 
 /**
+ * Limited variant of the shell tool used when the user has set
+ * `TERMINAL_ACCESS=limited` in `~/.omnikey/config.json` (Settings → Agent Access).
+ * The functional surface area is identical (the script still runs on the user's
+ * machine through the same WebSocket pipeline), but the description tells the
+ * model to stay within read-only / inspection commands and never perform
+ * destructive or system-altering operations. This is a soft, prompt-level
+ * restriction — there is no kernel-level sandbox — but it is the same model
+ * the rest of the agent uses to scope behaviour (system prompt + tool
+ * description).
+ */
+export const SHELL_SCRIPT_TOOL_LIMITED: AITool = {
+  name: 'shell_script',
+  description:
+    "Execute a READ-ONLY shell script on the user's machine. Terminal access is set to LIMITED — the script must only inspect state (ls, cat, grep, ps, env, which, stat, head, tail, df, du, uname, echo, printenv, etc.) and MUST NOT modify the filesystem, install packages, change configuration, kill processes, write/delete files, or make outbound mutating network calls. If a task requires mutation, respond with <final_answer> explaining that terminal access is limited and ask the user to enable full access in Settings.",
+  parameters: {
+    type: 'object',
+    properties: {
+      script: {
+        type: 'string',
+        description:
+          "Read-only shell script. Restrict yourself to inspection commands; do not write, delete, install, configure, or otherwise mutate state.",
+      },
+    },
+    required: ['script'],
+  },
+};
+
+/**
  * Returns the set of web tools available to the agent for every turn.
  *
  * `web_search` is always included because DuckDuckGo is used as a free
@@ -52,7 +80,14 @@ export const SHELL_SCRIPT_TOOL: AITool = {
  * @returns An array of `AITool` definitions ready to pass to the AI client.
  */
 export function buildAvailableTools(extraTools: AITool[] = []): AITool[] {
-  const baseTools: AITool[] = [WEB_FETCH_TOOL, WEB_SEARCH_TOOL];
+  // Web tools are registered only when the user has not opted out via the
+  // Settings UI (WEB_SEARCH_ENABLED in ~/.omnikey/config.json). Removing the
+  // tool definitions outright — rather than keeping them and refusing at the
+  // dispatch layer — keeps the model from being tempted to call them and
+  // matches how MCP-only tools are gated elsewhere in the agent.
+  const baseTools: AITool[] = config.webSearchEnabled
+    ? [WEB_FETCH_TOOL, WEB_SEARCH_TOOL]
+    : [];
   if (providerSupportsImageGeneration(config.aiProvider)) {
     baseTools.push(IMAGE_GENERATE_TOOL);
   }

--- a/api/src/ai-client.ts
+++ b/api/src/ai-client.ts
@@ -621,7 +621,7 @@ function toResponsesTools(tools: AITool[]): any[] {
  * intercepts calls to this tool and converts them to the <shell_script> tag
  * format that the rest of the agent pipeline expects.
  */
-const RESPONSES_SHELL_TOOL = {
+const RESPONSES_SHELL_TOOL_FULL = {
   type: 'function' as const,
   name: 'execute_shell_script',
   description:
@@ -635,6 +635,38 @@ const RESPONSES_SHELL_TOOL = {
   },
   strict: false,
 };
+
+/**
+ * Limited variant of the gpt-5.5 shell tool. Same wire format as
+ * RESPONSES_SHELL_TOOL_FULL, but the description tells the model that
+ * terminal access is restricted to read-only inspection commands. Selected
+ * at request time based on `config.terminalAccess`, which the macOS Settings
+ * UI writes to ~/.omnikey/config.json.
+ */
+const RESPONSES_SHELL_TOOL_LIMITED = {
+  type: 'function' as const,
+  name: 'execute_shell_script',
+  description:
+    'Execute a READ-ONLY shell script on the user\'s machine. Terminal access is set to LIMITED — restrict yourself to inspection commands (ls, cat, grep, ps, env, which, stat, head, tail, df, du, uname, echo, printenv) and never write to the filesystem, install packages, change configuration, kill processes, or perform mutating network calls. If the task needs mutation, return a <final_answer> telling the user to enable full terminal access in Settings.',
+  parameters: {
+    type: 'object',
+    properties: {
+      script: {
+        type: 'string',
+        description:
+          'Read-only shell script. Restrict yourself to inspection commands; do not write, delete, install, configure, or otherwise mutate state.',
+      },
+    },
+    required: ['script'],
+  },
+  strict: false,
+};
+
+function getResponsesShellTool() {
+  return config.terminalAccess === 'limited'
+    ? RESPONSES_SHELL_TOOL_LIMITED
+    : RESPONSES_SHELL_TOOL_FULL;
+}
 
 /**
  * Translates a Responses API response object into our normalised
@@ -878,7 +910,7 @@ class OpenAIResponsesAdapter {
     // Always inject the shell tool so gpt-5.5 can call execute_shell_script
     // natively; the adapter converts those calls back to <shell_script> tags.
     const userTools = options.tools?.length ? toResponsesTools(options.tools) : [];
-    const tools = [RESPONSES_SHELL_TOOL, ...userTools];
+    const tools = [getResponsesShellTool(), ...userTools];
 
     const response = await (this.client.responses as any).create({
       model,

--- a/api/src/appSettingsRoutes.ts
+++ b/api/src/appSettingsRoutes.ts
@@ -48,18 +48,41 @@ function getConfigPath(): string {
 
 function readConfigFile(): Record<string, any> {
   const configPath = getConfigPath();
-  try {
-    if (fs.existsSync(configPath)) {
-      const raw = fs.readFileSync(configPath, 'utf-8');
-      const parsed = JSON.parse(raw);
-      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-        return parsed;
-      }
-    }
-  } catch (err) {
-    logger.warn('Could not read ~/.omnikey/config.json — treating as empty.', { error: err });
+  // Missing file is the only safe "empty config" case. A truncated or
+  // malformed file must abort the request — otherwise a PATCH/POST would
+  // silently overwrite the rest of the user's saved keys with the few
+  // fields the handler is touching. See CodeRabbit PR #18 review.
+  if (!fs.existsSync(configPath)) {
+    return {};
   }
-  return {};
+  let raw: string;
+  try {
+    raw = fs.readFileSync(configPath, 'utf-8');
+  } catch (err) {
+    logger.error('Failed to read ~/.omnikey/config.json.', { error: err, configPath });
+    throw new Error(
+      `Could not read config file at ${configPath}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    logger.error('Failed to parse ~/.omnikey/config.json — refusing to mutate.', {
+      error: err,
+      configPath,
+    });
+    throw new Error(
+      `Config file at ${configPath} is not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    logger.error('~/.omnikey/config.json is not a JSON object — refusing to mutate.', {
+      configPath,
+    });
+    throw new Error(`Config file at ${configPath} is not a JSON object.`);
+  }
+  return parsed as Record<string, any>;
 }
 
 function writeConfigFile(data: Record<string, any>): void {
@@ -82,12 +105,17 @@ function readWebSearchEnabled(cfg: Record<string, any>): boolean {
 }
 
 function readBrowserAccessEnabled(cfg: Record<string, any>): boolean {
-  // A browser-access setup writes BROWSER_DEBUG_EXECUTABLE (alongside the
-  // port and user-data dir) — treat the presence of those keys as the truth
-  // even if BROWSER_ACCESS_ENABLED is not explicitly set.
+  // BROWSER_ACCESS_ENABLED, when explicitly set, is the source of truth. This
+  // matters during the enable flow: we write BROWSER_ACCESS_ENABLED=true the
+  // moment the user toggles the switch, but the CLI does not write the
+  // BROWSER_DEBUG_* keys until the user finishes the Terminal prompts. Without
+  // the explicit-true short-circuit, a GET refresh during that window would
+  // report `browserAccessEnabled: false` and bounce the UI toggle back off.
+  // Falls back to "do the debug keys exist?" when the flag is not set.
   if (cfg.BROWSER_ACCESS_ENABLED !== undefined) {
     const v = String(cfg.BROWSER_ACCESS_ENABLED).toLowerCase();
     if (v === 'false' || v === '0') return false;
+    if (v === 'true' || v === '1') return true;
   }
   return Boolean(cfg.BROWSER_DEBUG_EXECUTABLE);
 }
@@ -306,14 +334,21 @@ export function appSettingsRouter(): express.Router {
           });
         }
 
+        // NOTE: We deliberately do NOT call scheduleDaemonRestart() here. The
+        // user has not yet finished the interactive prompts in Terminal, so
+        // BROWSER_DEBUG_* keys are not in config.json yet — restarting now
+        // would just bounce the daemon against the pre-setup config. The
+        // omnikey grant-browser-access flow itself schedules a daemon restart
+        // once it has successfully written the debug-profile fields, so the
+        // running process picks up the new browser config without a second
+        // round-trip through this endpoint. See CodeRabbit PR #18 review.
         res.json({
           browserAccessEnabled: true,
           launched: true,
           message:
-            'Follow the prompts in the Terminal window to finish setting up authenticated browser access.',
-          restartScheduled: true,
+            'Follow the prompts in the Terminal window to finish setting up authenticated browser access. The daemon will restart automatically once setup is complete.',
+          restartScheduled: false,
         });
-        scheduleDaemonRestart('enabled browser access');
         return;
       }
 

--- a/api/src/appSettingsRoutes.ts
+++ b/api/src/appSettingsRoutes.ts
@@ -1,0 +1,338 @@
+import express from 'express';
+import zod from 'zod';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { spawn } from 'child_process';
+import { authMiddleware } from './authMiddleware';
+import { config } from './config';
+import { logger } from './logger';
+
+/**
+ * Settings endpoint for "Agent Access" controls (terminal access mode, web
+ * search toggle, authenticated browser session reading). The persistence
+ * model is identical to aiProviderRoutes: ~/.omnikey/config.json is the
+ * source of truth, the running daemon reads it via dotenv on startup, and
+ * any change that affects already-loaded config triggers a detached
+ * `omnikey restart-daemon` so the new values take effect.
+ *
+ * Browser access is special — enabling it spawns the interactive
+ * `omnikey grant-browser-access` command in a new Terminal window so the
+ * existing inquirer prompts (browser selection, profile naming, etc.) work
+ * unchanged. Disabling it removes the saved BROWSER_DEBUG_* keys and the
+ * macOS LaunchAgent that auto-launches the debug profile, mirroring the
+ * "Remove" path inside the CLI.
+ */
+
+type TerminalAccessMode = 'full' | 'limited';
+
+const updateSchema = zod
+  .object({
+    terminalAccess: zod.enum(['full', 'limited']).optional(),
+    webSearchEnabled: zod.boolean().optional(),
+  })
+  .strict();
+
+const MACOS_LAUNCH_AGENT_LABEL = 'com.omnikey.browser-debug';
+const MACOS_LAUNCH_AGENT_PATH = path.join(
+  process.env.HOME || os.homedir(),
+  'Library',
+  'LaunchAgents',
+  `${MACOS_LAUNCH_AGENT_LABEL}.plist`,
+);
+
+function getConfigPath(): string {
+  const home = process.env.HOME || process.env.USERPROFILE || os.homedir();
+  return path.join(home, '.omnikey', 'config.json');
+}
+
+function readConfigFile(): Record<string, any> {
+  const configPath = getConfigPath();
+  try {
+    if (fs.existsSync(configPath)) {
+      const raw = fs.readFileSync(configPath, 'utf-8');
+      const parsed = JSON.parse(raw);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return parsed;
+      }
+    }
+  } catch (err) {
+    logger.warn('Could not read ~/.omnikey/config.json — treating as empty.', { error: err });
+  }
+  return {};
+}
+
+function writeConfigFile(data: Record<string, any>): void {
+  const configPath = getConfigPath();
+  fs.mkdirSync(path.dirname(configPath), { recursive: true });
+  fs.writeFileSync(configPath, JSON.stringify(data, null, 2), 'utf-8');
+}
+
+function readTerminalAccess(cfg: Record<string, any>): TerminalAccessMode {
+  return cfg.TERMINAL_ACCESS === 'limited' ? 'limited' : 'full';
+}
+
+function readWebSearchEnabled(cfg: Record<string, any>): boolean {
+  // Mirrors the getBooleanEnv default in config.ts: undefined → true.
+  if (cfg.WEB_SEARCH_ENABLED === undefined || cfg.WEB_SEARCH_ENABLED === null) {
+    return true;
+  }
+  const v = String(cfg.WEB_SEARCH_ENABLED).toLowerCase();
+  return v === 'true' || v === '1';
+}
+
+function readBrowserAccessEnabled(cfg: Record<string, any>): boolean {
+  // A browser-access setup writes BROWSER_DEBUG_EXECUTABLE (alongside the
+  // port and user-data dir) — treat the presence of those keys as the truth
+  // even if BROWSER_ACCESS_ENABLED is not explicitly set.
+  if (cfg.BROWSER_ACCESS_ENABLED !== undefined) {
+    const v = String(cfg.BROWSER_ACCESS_ENABLED).toLowerCase();
+    if (v === 'false' || v === '0') return false;
+  }
+  return Boolean(cfg.BROWSER_DEBUG_EXECUTABLE);
+}
+
+/**
+ * Daemon restart scheduler — copied in spirit from aiProviderRoutes so the
+ * three settings endpoints share the same restart contract. Detached spawn
+ * keeps the new process alive after the parent (current API server) exits.
+ */
+function scheduleDaemonRestart(reason: string): void {
+  setTimeout(() => {
+    const port = config.port;
+    const home = process.env.HOME || os.homedir();
+    const logFile = path.join(home, '.omnikey', 'restart-daemon.log');
+    const omnikeyCli = path.resolve(__dirname, '../dist/index.js');
+
+    logger.info(`Spawning detached \`omnikey restart-daemon --port ${port}\` (${reason})`);
+
+    try {
+      fs.mkdirSync(path.dirname(logFile), { recursive: true });
+      const out = fs.openSync(logFile, 'a');
+      const child = spawn(
+        process.execPath,
+        [omnikeyCli, 'restart-daemon', '--port', String(port)],
+        { detached: true, stdio: ['ignore', out, out] },
+      );
+      child.unref();
+      fs.closeSync(out);
+    } catch (err) {
+      logger.error('Failed to spawn restart-daemon process.', { error: err });
+    }
+  }, 500);
+}
+
+/**
+ * Spawns `omnikey grant-browser-access` inside a new Terminal.app window so
+ * the interactive inquirer prompts (browser selection, profile naming, etc.)
+ * remain reachable. The macOS app cannot host inquirer directly without
+ * reimplementing every prompt, so we delegate to the existing CLI flow —
+ * the same one a user would run manually.
+ */
+function launchGrantBrowserAccessInteractive(): { launched: boolean; error?: string } {
+  if (process.platform !== 'darwin') {
+    return { launched: false, error: 'Interactive browser-access setup is only wired for macOS in the Settings UI.' };
+  }
+
+  const omnikeyCli = path.resolve(__dirname, '../dist/index.js');
+  const node = process.execPath;
+  if (!fs.existsSync(omnikeyCli)) {
+    return { launched: false, error: `omnikey CLI not found at ${omnikeyCli}` };
+  }
+
+  // Escape for embedding inside the AppleScript string literal.
+  const escapeForAppleScript = (s: string): string =>
+    s.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+
+  const command = `clear; "${escapeForAppleScript(node)}" "${escapeForAppleScript(omnikeyCli)}" grant-browser-access; echo; echo "[Press Enter to close]"; read`;
+  const appleScript = `tell application "Terminal"
+    activate
+    do script "${command.replace(/"/g, '\\"')}"
+end tell`;
+
+  try {
+    const child = spawn('/usr/bin/osascript', ['-e', appleScript], {
+      detached: true,
+      stdio: 'ignore',
+    });
+    child.unref();
+    return { launched: true };
+  } catch (err) {
+    return {
+      launched: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+/**
+ * Tears down a previously-configured browser debug profile: clears the
+ * BROWSER_DEBUG_* keys from config.json, sets BROWSER_ACCESS_ENABLED=false,
+ * and unloads + deletes the macOS LaunchAgent the CLI created. The actual
+ * debug profile directory under ~/.omnikey/browser-debug-profiles is kept
+ * so re-enabling is fast and the user does not lose any signed-in state.
+ */
+function disableBrowserAccess(cfg: Record<string, any>): void {
+  delete cfg.BROWSER_DEBUG_PORT;
+  delete cfg.BROWSER_DEBUG_BROWSER_NAME;
+  delete cfg.BROWSER_DEBUG_EXECUTABLE;
+  delete cfg.BROWSER_DEBUG_USER_DATA_DIR;
+  cfg.BROWSER_ACCESS_ENABLED = false;
+  writeConfigFile(cfg);
+
+  if (process.platform !== 'darwin') return;
+  if (!fs.existsSync(MACOS_LAUNCH_AGENT_PATH)) return;
+  try {
+    // Best-effort unload, then delete. Failure here is non-fatal — the user
+    // can always remove the plist by hand if launchctl refuses.
+    spawn('/bin/launchctl', ['unload', MACOS_LAUNCH_AGENT_PATH], { stdio: 'ignore' });
+    fs.unlinkSync(MACOS_LAUNCH_AGENT_PATH);
+  } catch (err) {
+    logger.warn('Failed to unload/remove macOS browser-debug LaunchAgent.', { error: err });
+  }
+}
+
+export function appSettingsRouter(): express.Router {
+  const router = express.Router();
+
+  /** GET /api/app-settings — current values + runtime snapshot. */
+  router.get('/', authMiddleware, async (_req, res) => {
+    const { logger: reqLogger } = res.locals;
+    try {
+      const cfg = readConfigFile();
+      res.json({
+        terminalAccess: readTerminalAccess(cfg),
+        webSearchEnabled: readWebSearchEnabled(cfg),
+        browserAccessEnabled: readBrowserAccessEnabled(cfg),
+        browserDebugBrowserName: cfg.BROWSER_DEBUG_BROWSER_NAME ?? null,
+        browserDebugPort:
+          typeof cfg.BROWSER_DEBUG_PORT === 'number'
+            ? cfg.BROWSER_DEBUG_PORT
+            : Number.isFinite(Number(cfg.BROWSER_DEBUG_PORT))
+              ? Number(cfg.BROWSER_DEBUG_PORT)
+              : null,
+        // Runtime view so the UI can warn if config.json drifted from the
+        // values currently loaded into the process.
+        runtime: {
+          terminalAccess: config.terminalAccess,
+          webSearchEnabled: config.webSearchEnabled,
+          browserAccessEnabled:
+            config.browserAccessEnabled || Boolean(config.browserDebugExecutable),
+        },
+      });
+    } catch (err) {
+      reqLogger.error('Error reading app settings.', { error: err });
+      res.status(500).json({ error: 'Failed to read app settings.' });
+    }
+  });
+
+  /**
+   * PATCH /api/app-settings — partial update of terminalAccess and/or
+   * webSearchEnabled. Always restarts the daemon so the new values land in
+   * `config` before the next agent turn.
+   */
+  router.patch('/', authMiddleware, async (req, res) => {
+    const { logger: reqLogger } = res.locals;
+    try {
+      const parsed = updateSchema.parse(req.body);
+      if (
+        parsed.terminalAccess === undefined &&
+        parsed.webSearchEnabled === undefined
+      ) {
+        return res.status(400).json({ error: 'No supported fields supplied.' });
+      }
+
+      const cfg = readConfigFile();
+      const reasons: string[] = [];
+      if (parsed.terminalAccess !== undefined) {
+        cfg.TERMINAL_ACCESS = parsed.terminalAccess;
+        reasons.push(`terminalAccess=${parsed.terminalAccess}`);
+      }
+      if (parsed.webSearchEnabled !== undefined) {
+        cfg.WEB_SEARCH_ENABLED = parsed.webSearchEnabled;
+        reasons.push(`webSearchEnabled=${parsed.webSearchEnabled}`);
+      }
+      writeConfigFile(cfg);
+
+      res.json({
+        terminalAccess: readTerminalAccess(cfg),
+        webSearchEnabled: readWebSearchEnabled(cfg),
+        browserAccessEnabled: readBrowserAccessEnabled(cfg),
+        restartScheduled: true,
+        message: 'Settings updated. Server will restart shortly to apply the change.',
+      });
+
+      scheduleDaemonRestart(`updated app settings (${reasons.join(', ')})`);
+    } catch (err: any) {
+      reqLogger.error('Error updating app settings.', { error: err });
+      if (err instanceof zod.ZodError) {
+        return res.status(400).json({ error: 'Invalid settings payload.' });
+      }
+      res.status(500).json({ error: 'Failed to update app settings.' });
+    }
+  });
+
+  /**
+   * POST /api/app-settings/browser-access — toggle authenticated browser
+   * session reading. Enabling spawns the interactive CLI in a new Terminal
+   * window (the user finishes the setup there); disabling clears the saved
+   * debug profile config and unloads the LaunchAgent.
+   *
+   * Body: { enabled: boolean }
+   */
+  router.post('/browser-access', authMiddleware, async (req, res) => {
+    const { logger: reqLogger } = res.locals;
+    const bodySchema = zod.object({ enabled: zod.boolean() });
+    try {
+      const { enabled } = bodySchema.parse(req.body);
+      const cfg = readConfigFile();
+
+      if (enabled) {
+        // Mark intent in config so the GET endpoint reflects "enabling" even
+        // before the user finishes the Terminal prompts. The CLI itself will
+        // overwrite BROWSER_DEBUG_* on completion.
+        cfg.BROWSER_ACCESS_ENABLED = true;
+        writeConfigFile(cfg);
+
+        const launch = launchGrantBrowserAccessInteractive();
+        if (!launch.launched) {
+          // Revert the intent flag so the toggle does not stay on incorrectly.
+          cfg.BROWSER_ACCESS_ENABLED = false;
+          writeConfigFile(cfg);
+          return res.status(500).json({
+            error:
+              launch.error ||
+              'Failed to launch the interactive browser-access setup.',
+          });
+        }
+
+        res.json({
+          browserAccessEnabled: true,
+          launched: true,
+          message:
+            'Follow the prompts in the Terminal window to finish setting up authenticated browser access.',
+          restartScheduled: true,
+        });
+        scheduleDaemonRestart('enabled browser access');
+        return;
+      }
+
+      disableBrowserAccess(cfg);
+      res.json({
+        browserAccessEnabled: false,
+        launched: false,
+        message: 'Authenticated browser access disabled.',
+        restartScheduled: true,
+      });
+      scheduleDaemonRestart('disabled browser access');
+    } catch (err: any) {
+      reqLogger.error('Error toggling browser access.', { error: err });
+      if (err instanceof zod.ZodError) {
+        return res.status(400).json({ error: 'Invalid request payload.' });
+      }
+      res.status(500).json({ error: 'Failed to toggle browser access.' });
+    }
+  });
+
+  return router;
+}

--- a/api/src/config.ts
+++ b/api/src/config.ts
@@ -43,6 +43,14 @@ function getSqlitePath() {
 
 export type AIProvider = 'openai' | 'gemini' | 'anthropic' | 'nemotron';
 
+export type TerminalAccessMode = 'full' | 'limited';
+
+function getTerminalAccessMode(): TerminalAccessMode {
+  const value = getEnv('TERMINAL_ACCESS', false);
+  if (value === 'limited') return 'limited';
+  return 'full';
+}
+
 function getAIProvider(): AIProvider {
   const value = getEnv('AI_PROVIDER', false);
   if (value === 'gemini' || value === 'anthropic' || value === 'openai' || value === 'nemotron') {
@@ -127,6 +135,20 @@ export const config = {
   browserDebugBrowserName: getEnv('BROWSER_DEBUG_BROWSER_NAME', false),
   browserDebugExecutable: getEnv('BROWSER_DEBUG_EXECUTABLE', false),
   browserDebugUserDataDir: getEnv('BROWSER_DEBUG_USER_DATA_DIR', false),
+
+  // Agent capability toggles, surfaced in the macOS Settings UI.
+  // terminalAccess controls how broad the shell tool is — 'full' exposes the
+  // shell_script tool as-is; 'limited' restricts the tool description so the
+  // model only runs read-only / safe commands and the prompts discourage
+  // mutating operations.
+  terminalAccess: getTerminalAccessMode(),
+  // webSearchEnabled controls whether web_search / web_fetch tools are
+  // registered with the agent at all. Defaults to true.
+  webSearchEnabled: getBooleanEnv('WEB_SEARCH_ENABLED', true),
+  // browserAccessEnabled toggles authenticated browser session reading.
+  // Setting it to true triggers `omnikey grant-browser-access` from the
+  // settings endpoint (similar to `restart-daemon`).
+  browserAccessEnabled: getBooleanEnv('BROWSER_ACCESS_ENABLED', false),
 
   // GCS download-count tracking (both must be set to enable counting)
   gcsBucketName: getEnv('GCS_BUCKET_NAME', false),

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -11,6 +11,7 @@ import { taskInstructionRouter } from './taskInstructionRoutes';
 import { scheduledJobRouter } from './scheduledJobRoutes';
 import { mcpServerRouter } from './mcpServerRoutes';
 import { aiProviderRouter } from './aiProviderRoutes';
+import { appSettingsRouter } from './appSettingsRoutes';
 import { spawnWorker, type ManagedWorker } from './workers/spawn';
 import { setScheduledJobWorker } from './workers/scheduledJobWorkerClient';
 import { config } from './config';
@@ -43,6 +44,8 @@ app.use('/api/scheduled-jobs', scheduledJobRouter());
 app.use('/api/mcp-servers', mcpServerRouter());
 
 app.use('/api/providers', aiProviderRouter());
+
+app.use('/api/app-settings', appSettingsRouter());
 
 app.use('/api/agent', createAgentRouter());
 

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -101,8 +101,8 @@ app.get('/macos/appcast', (req, res) => {
 
   // These should match the values embedded into the macOS app
   // Info.plist in macOS/build_release_dmg.sh.
-  const bundleVersion = '40';
-  const shortVersion = '1.0.39';
+  const bundleVersion = '41';
+  const shortVersion = '1.0.40';
 
   const xml = `<?xml version="1.0" encoding="utf-8"?>
 <rss version="2.0"

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "omnikey-cli",
-  "version": "1.6.7",
+  "version": "1.6.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "omnikey-cli",
-      "version": "1.6.7",
+      "version": "1.6.9",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.96.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -4,7 +4,7 @@
     "access": "public",
     "registry": "https://registry.npmjs.org/"
   },
-  "version": "1.6.8",
+  "version": "1.6.9",
   "description": "CLI for onboarding users to Omnikey AI and configuring OPENAI_API_KEY. Use Yarn for install/build.",
   "engines": {
     "node": ">=14.0.0",

--- a/cli/src/grantBrowserAccess.ts
+++ b/cli/src/grantBrowserAccess.ts
@@ -5,7 +5,7 @@ import net from 'net';
 import http from 'http';
 import os from 'os';
 import { execSync, spawn } from 'child_process';
-import { getConfigDir, getConfigPath, readConfig, isWindows } from './utils';
+import { getConfigDir, getConfigPath, readConfig, isWindows, getPort } from './utils';
 
 interface BrowserEntry {
   name: string;
@@ -137,6 +137,44 @@ function getInstalledBrowsers(catalogue: BrowserEntry[]): InstalledBrowser[] {
       return executablePath ? { ...b, executablePath } : null;
     })
     .filter((b): b is InstalledBrowser => b !== null);
+}
+
+/**
+ * Best-effort daemon restart trigger. Used by the macOS Settings UI's
+ * "Authenticated browser access" toggle: enabling fires
+ * `omnikey grant-browser-access` in a new Terminal window, and the daemon
+ * cannot restart until *after* the user has finished the interactive prompts
+ * (because that's when BROWSER_DEBUG_* finally lands in config.json). To keep
+ * the running daemon in sync without forcing a second manual step, we
+ * schedule a detached `omnikey restart-daemon` on successful completion of
+ * the setup flow. The spawn is detached + unrefed so the CLI process can
+ * exit cleanly. Failures are swallowed — the user can always restart by hand.
+ */
+function scheduleDaemonRestart(reason: string): void {
+  try {
+    const omnikeyCli = path.resolve(__dirname, 'index.js');
+    const node = process.execPath;
+    const port = getPort();
+    const home = process.env.HOME || process.env.USERPROFILE || os.homedir();
+    const logFile = path.join(home, '.omnikey', 'restart-daemon.log');
+    fs.mkdirSync(path.dirname(logFile), { recursive: true });
+    const out = fs.openSync(logFile, 'a');
+    const child = spawn(node, [omnikeyCli, 'restart-daemon', '--port', String(port)], {
+      detached: true,
+      stdio: ['ignore', out, out],
+    });
+    child.unref();
+    fs.closeSync(out);
+    console.log(`
+Restarting Omnikey daemon to pick up the new browser config (${reason}).`);
+  } catch (err) {
+    console.warn(
+      `
+Could not auto-restart Omnikey daemon: ${err instanceof Error ? err.message : String(err)}
+` +
+        `Run \`omnikey restart-daemon\` manually so the new browser config takes effect.`,
+    );
+  }
 }
 
 function isPortAvailable(port: number): Promise<boolean> {
@@ -471,6 +509,7 @@ async function setupDebuggingPort(browser: InstalledBrowser): Promise<void> {
         `Omnikey can now access tabs opened in the Omnikey-managed ${browser.name} debug profile.\n` +
         `${browser.name} will start automatically on every future login using this debug profile.`,
     );
+    scheduleDaemonRestart('grant-browser-access completed');
   } else {
     console.error(
       `\nCould not reach localhost:${port} after 15 s.\n` +

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -26,7 +26,7 @@ const program = new Command();
 program
   .name('omnikey')
   .description('Omnikey CLI for onboarding and configuration')
-  .version('1.6.0');
+  .version('1.6.9');
 
 program
   .command('onboard')

--- a/macOS/Sources/APIClient.swift
+++ b/macOS/Sources/APIClient.swift
@@ -1161,4 +1161,171 @@ final class APIClient: @unchecked Sendable {
         catch { completion(.failure(error)) }
     }
 
+    // MARK: - Agent Access (terminal / web search / browser access)
+
+    private var appSettingsBaseURL: URL { APIClient.baseURL.appendingPathComponent("api/app-settings") }
+
+    /// Terminal access mode, mirroring the backend's TerminalAccessMode type.
+    /// Persisted to TERMINAL_ACCESS in ~/.omnikey/config.json.
+    enum TerminalAccessMode: String, Codable, CaseIterable, Identifiable {
+        case full
+        case limited
+        var id: String { rawValue }
+    }
+
+    /// Snapshot returned by GET /api/app-settings.
+    struct AppSettingsResponse: Codable {
+        let terminalAccess: TerminalAccessMode
+        let webSearchEnabled: Bool
+        let browserAccessEnabled: Bool
+        let browserDebugBrowserName: String?
+        let browserDebugPort: Int?
+    }
+
+    /// Server response shape for the GET endpoint. The "runtime" object is
+    /// available but currently unused in the UI; kept here as a CodingKey
+    /// so it does not surface as a JSON-decode error.
+    private struct AppSettingsEnvelope: Codable {
+        let terminalAccess: TerminalAccessMode
+        let webSearchEnabled: Bool
+        let browserAccessEnabled: Bool
+        let browserDebugBrowserName: String?
+        let browserDebugPort: Int?
+    }
+
+    /// Response from the PATCH endpoint and the browser-access POST endpoint.
+    struct AppSettingsMutationResponse: Codable {
+        let terminalAccess: TerminalAccessMode
+        let webSearchEnabled: Bool
+        let browserAccessEnabled: Bool
+        let restartScheduled: Bool?
+        let message: String?
+    }
+
+    /// Response from POST /api/app-settings/browser-access.
+    struct BrowserAccessMutationResponse: Codable {
+        let browserAccessEnabled: Bool
+        let launched: Bool?
+        let message: String?
+        let restartScheduled: Bool?
+    }
+
+    func fetchAppSettings(completion: @escaping @Sendable (Result<AppSettingsResponse, Error>) -> Void) {
+        var request = URLRequest(url: appSettingsBaseURL)
+        request.httpMethod = "GET"
+        if let token = SubscriptionManager.shared.jwtToken {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        let task = URLSession.shared.dataTask(with: request) { data, response, error in
+            if let error = error { completion(.failure(error)); return }
+            guard let httpResponse = response as? HTTPURLResponse else {
+                completion(.failure(NSError(domain: "APIClient", code: -1, userInfo: [NSLocalizedDescriptionKey: "Invalid response"])))
+                return
+            }
+            guard (200...299).contains(httpResponse.statusCode) else {
+                completion(.failure(APIClient.makeBackendError(statusCode: httpResponse.statusCode, data: data)))
+                return
+            }
+            guard let data = data, !data.isEmpty else {
+                completion(.failure(NSError(domain: "APIClient", code: -1, userInfo: [NSLocalizedDescriptionKey: "No data"])))
+                return
+            }
+            do {
+                let decoded = try JSONDecoder().decode(AppSettingsEnvelope.self, from: data)
+                completion(.success(AppSettingsResponse(
+                    terminalAccess: decoded.terminalAccess,
+                    webSearchEnabled: decoded.webSearchEnabled,
+                    browserAccessEnabled: decoded.browserAccessEnabled,
+                    browserDebugBrowserName: decoded.browserDebugBrowserName,
+                    browserDebugPort: decoded.browserDebugPort
+                )))
+            } catch { completion(.failure(error)) }
+        }
+        task.resume()
+    }
+
+    /// Partial update of the simple settings (terminal access and web search).
+    /// Each parameter is independently nullable; pass nil to leave that value
+    /// untouched. The backend rejects an empty payload with 400.
+    func updateAppSettings(
+        terminalAccess: TerminalAccessMode?,
+        webSearchEnabled: Bool?,
+        completion: @escaping @Sendable (Result<AppSettingsMutationResponse, Error>) -> Void
+    ) {
+        var request = URLRequest(url: appSettingsBaseURL)
+        request.httpMethod = "PATCH"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if let token = SubscriptionManager.shared.jwtToken {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        var payload: [String: Any] = [:]
+        if let mode = terminalAccess { payload["terminalAccess"] = mode.rawValue }
+        if let webSearch = webSearchEnabled { payload["webSearchEnabled"] = webSearch }
+        guard !payload.isEmpty,
+              let body = try? JSONSerialization.data(withJSONObject: payload) else {
+            completion(.failure(NSError(domain: "APIClient", code: -1, userInfo: [NSLocalizedDescriptionKey: "Nothing to update"])))
+            return
+        }
+        request.httpBody = body
+        let task = URLSession.shared.dataTask(with: request) { data, response, error in
+            if let error = error { completion(.failure(error)); return }
+            guard let httpResponse = response as? HTTPURLResponse else {
+                completion(.failure(NSError(domain: "APIClient", code: -1, userInfo: [NSLocalizedDescriptionKey: "Invalid response"])))
+                return
+            }
+            guard (200...299).contains(httpResponse.statusCode) else {
+                completion(.failure(APIClient.makeBackendError(statusCode: httpResponse.statusCode, data: data)))
+                return
+            }
+            guard let data = data, !data.isEmpty else {
+                completion(.failure(NSError(domain: "APIClient", code: -1, userInfo: [NSLocalizedDescriptionKey: "No data"])))
+                return
+            }
+            do { completion(.success(try JSONDecoder().decode(AppSettingsMutationResponse.self, from: data))) }
+            catch { completion(.failure(error)) }
+        }
+        task.resume()
+    }
+
+    /// Toggle authenticated browser session access. Enabling spawns
+    /// `omnikey grant-browser-access` inside a new Terminal window so the
+    /// existing interactive prompts (browser pick, profile name, etc.) work
+    /// unchanged. Disabling clears the saved BROWSER_DEBUG_* config and
+    /// removes the macOS LaunchAgent.
+    func setBrowserAccessEnabled(
+        _ enabled: Bool,
+        completion: @escaping @Sendable (Result<BrowserAccessMutationResponse, Error>) -> Void
+    ) {
+        let url = appSettingsBaseURL.appendingPathComponent("browser-access")
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if let token = SubscriptionManager.shared.jwtToken {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        guard let body = try? JSONSerialization.data(withJSONObject: ["enabled": enabled]) else {
+            completion(.failure(NSError(domain: "APIClient", code: -1, userInfo: [NSLocalizedDescriptionKey: "Serialization error"])))
+            return
+        }
+        request.httpBody = body
+        let task = URLSession.shared.dataTask(with: request) { data, response, error in
+            if let error = error { completion(.failure(error)); return }
+            guard let httpResponse = response as? HTTPURLResponse else {
+                completion(.failure(NSError(domain: "APIClient", code: -1, userInfo: [NSLocalizedDescriptionKey: "Invalid response"])))
+                return
+            }
+            guard (200...299).contains(httpResponse.statusCode) else {
+                completion(.failure(APIClient.makeBackendError(statusCode: httpResponse.statusCode, data: data)))
+                return
+            }
+            guard let data = data, !data.isEmpty else {
+                completion(.failure(NSError(domain: "APIClient", code: -1, userInfo: [NSLocalizedDescriptionKey: "No data"])))
+                return
+            }
+            do { completion(.success(try JSONDecoder().decode(BrowserAccessMutationResponse.self, from: data))) }
+            catch { completion(.failure(error)) }
+        }
+        task.resume()
+    }
+
 }

--- a/macOS/Sources/AgentAccessSettingsView.swift
+++ b/macOS/Sources/AgentAccessSettingsView.swift
@@ -1,0 +1,397 @@
+import SwiftUI
+
+/// Settings pane that controls how broad the agent's machine access is:
+///   • Terminal access mode  — Full vs. Limited (read-only) shell scripts.
+///   • Web search             — Enable / disable web_search + web_fetch tools.
+///   • Authenticated browser  — Enable / disable browser session reading via
+///                              the same `omnikey grant-browser-access` flow
+///                              the CLI exposes.
+///
+/// All three values are persisted to ~/.omnikey/config.json by the backend
+/// (see appSettingsRoutes.ts) and any change schedules a daemon restart so
+/// the running process picks them up. Enabling browser access spawns the
+/// interactive CLI in Terminal.app — the same prompts the user would see
+/// from `omnikey grant-browser-access`.
+struct AgentAccessSettingsView: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    @State private var terminalAccess: APIClient.TerminalAccessMode = .full
+    @State private var webSearchEnabled: Bool = true
+    @State private var browserAccessEnabled: Bool = false
+    @State private var browserDebugBrowserName: String? = nil
+    @State private var browserDebugPort: Int? = nil
+
+    @State private var isLoading: Bool = false
+    @State private var statusMessage: String = ""
+
+    // Pending dialog state — mirrors the confirmation pattern used by the
+    // AI Providers pane so destructive / restart-inducing changes always
+    // require an explicit confirm step.
+    @State private var pendingTerminalAccess: APIClient.TerminalAccessMode? = nil
+    @State private var pendingWebSearch: Bool? = nil
+    @State private var pendingBrowserAccess: Bool? = nil
+
+    private let apiClient = APIClient()
+
+    var body: some View {
+        ZStack {
+            NordTheme.windowBackground(colorScheme)
+                .ignoresSafeArea()
+
+            VStack(alignment: .leading, spacing: 0) {
+                header
+                    .padding(.horizontal, 24)
+                    .padding(.top, 20)
+                    .padding(.bottom, 16)
+
+                Rectangle()
+                    .fill(NordTheme.border(colorScheme))
+                    .frame(height: 1)
+
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 14) {
+                        terminalAccessCard
+                        webSearchCard
+                        browserAccessCard
+                    }
+                    .padding(.horizontal, 24)
+                    .padding(.top, 16)
+                    .padding(.bottom, 12)
+                }
+
+                if !statusMessage.isEmpty {
+                    Text(statusMessage)
+                        .font(.system(size: 12))
+                        .foregroundColor(NordTheme.secondaryText(colorScheme))
+                        .padding(.horizontal, 24)
+                        .padding(.bottom, 12)
+                }
+            }
+        }
+        .onAppear { loadSettings() }
+        .confirmationDialog(
+            "Switch terminal access?",
+            isPresented: Binding(
+                get: { pendingTerminalAccess != nil },
+                set: { if !$0 { pendingTerminalAccess = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            Button("Apply & Restart Server") {
+                if let mode = pendingTerminalAccess {
+                    pendingTerminalAccess = nil
+                    applyTerminalAccess(mode)
+                }
+            }
+            Button("Cancel", role: .cancel) { pendingTerminalAccess = nil }
+        } message: {
+            let target = pendingTerminalAccess == .limited ? "Limited (read-only)" : "Full"
+            Text("TERMINAL_ACCESS will be set to \"\(target)\" in ~/.omnikey/config.json and the OmniKey daemon will restart. In-flight agent sessions will be interrupted.")
+        }
+        .confirmationDialog(
+            "Change web search setting?",
+            isPresented: Binding(
+                get: { pendingWebSearch != nil },
+                set: { if !$0 { pendingWebSearch = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            Button("Apply & Restart Server") {
+                if let enabled = pendingWebSearch {
+                    pendingWebSearch = nil
+                    applyWebSearch(enabled)
+                }
+            }
+            Button("Cancel", role: .cancel) { pendingWebSearch = nil }
+        } message: {
+            let target = (pendingWebSearch == true) ? "enabled" : "disabled"
+            Text("Web search and web fetch tools will be \(target). The daemon will restart to apply the change.")
+        }
+        .confirmationDialog(
+            (pendingBrowserAccess == true)
+                ? "Enable authenticated browser access?"
+                : "Disable authenticated browser access?",
+            isPresented: Binding(
+                get: { pendingBrowserAccess != nil },
+                set: { if !$0 { pendingBrowserAccess = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            Button((pendingBrowserAccess == true) ? "Continue in Terminal" : "Disable") {
+                if let enabled = pendingBrowserAccess {
+                    pendingBrowserAccess = nil
+                    applyBrowserAccess(enabled)
+                }
+            }
+            Button("Cancel", role: .cancel) { pendingBrowserAccess = nil }
+        } message: {
+            if pendingBrowserAccess == true {
+                Text("OmniKey will open a Terminal window and run `omnikey grant-browser-access`. Follow the prompts there to pick a browser and an Omnikey debug profile — the same steps as the CLI command.")
+            } else {
+                Text("This clears the saved browser debug profile (BROWSER_DEBUG_* keys) from ~/.omnikey/config.json and removes the macOS LaunchAgent. The debug profile directory itself is preserved so you can re-enable later without signing in again.")
+            }
+        }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 10) {
+                Image(systemName: "lock.shield.fill")
+                    .font(.system(size: 18, weight: .semibold))
+                    .foregroundColor(NordTheme.accent(colorScheme))
+                Text("Settings · Agent Access")
+                    .font(.system(size: 20, weight: .semibold))
+                    .foregroundColor(NordTheme.primaryText(colorScheme))
+                Spacer()
+                Button(action: loadSettings) {
+                    Label("Refresh", systemImage: "arrow.clockwise")
+                        .font(.system(size: 13, weight: .medium))
+                }
+                .buttonStyle(.bordered)
+                .tint(NordTheme.accentBlue(colorScheme))
+                .disabled(isLoading)
+            }
+
+            Text("Control which capabilities OmniKey's agent can use on this machine. Changes are saved to ~/.omnikey/config.json and the daemon is restarted to apply them.")
+                .font(.system(size: 13))
+                .foregroundColor(NordTheme.secondaryText(colorScheme))
+        }
+    }
+
+    // MARK: - Terminal access card
+
+    private var terminalAccessCard: some View {
+        settingCard(
+            icon: "terminal.fill",
+            title: "Terminal access",
+            subtitle: "Choose how much shell freedom the agent has when running scripts."
+        ) {
+            VStack(alignment: .leading, spacing: 10) {
+                Picker("", selection: Binding(
+                    get: { terminalAccess },
+                    set: { newValue in
+                        if newValue != terminalAccess {
+                            pendingTerminalAccess = newValue
+                        }
+                    }
+                )) {
+                    Text("Full access").tag(APIClient.TerminalAccessMode.full)
+                    Text("Limited (read-only)").tag(APIClient.TerminalAccessMode.limited)
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .disabled(isLoading)
+
+                Text(terminalAccess == .full
+                     ? "Full: the agent can run any shell command — read, write, install, configure, restart services."
+                     : "Limited: the agent is told to only run read-only inspection commands (ls, cat, grep, ps, env, …) and to refuse mutating tasks.")
+                    .font(.system(size: 11))
+                    .foregroundColor(NordTheme.secondaryText(colorScheme))
+            }
+        }
+    }
+
+    // MARK: - Web search card
+
+    private var webSearchCard: some View {
+        settingCard(
+            icon: "globe",
+            title: "Web search",
+            subtitle: "Enable the built-in web_search and web_fetch tools."
+        ) {
+            HStack {
+                Toggle(isOn: Binding(
+                    get: { webSearchEnabled },
+                    set: { newValue in
+                        if newValue != webSearchEnabled {
+                            pendingWebSearch = newValue
+                        }
+                    }
+                )) {
+                    Text(webSearchEnabled ? "Enabled" : "Disabled")
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundColor(NordTheme.primaryText(colorScheme))
+                }
+                .toggleStyle(.switch)
+                .labelsHidden()
+                .disabled(isLoading)
+                Text(webSearchEnabled ? "Enabled" : "Disabled")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundColor(NordTheme.primaryText(colorScheme))
+                Spacer()
+            }
+        }
+    }
+
+    // MARK: - Browser access card
+
+    private var browserAccessCard: some View {
+        settingCard(
+            icon: "safari.fill",
+            title: "Authenticated browser access",
+            subtitle: "Let the agent read content from your logged-in browser tabs via a dedicated debug profile."
+        ) {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack {
+                    Toggle(isOn: Binding(
+                        get: { browserAccessEnabled },
+                        set: { newValue in
+                            if newValue != browserAccessEnabled {
+                                pendingBrowserAccess = newValue
+                            }
+                        }
+                    )) {
+                        Text(browserAccessEnabled ? "Enabled" : "Disabled")
+                    }
+                    .toggleStyle(.switch)
+                    .labelsHidden()
+                    .disabled(isLoading)
+                    Text(browserAccessEnabled ? "Enabled" : "Disabled")
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundColor(NordTheme.primaryText(colorScheme))
+                    Spacer()
+                }
+
+                if browserAccessEnabled,
+                   let name = browserDebugBrowserName, !name.isEmpty {
+                    HStack(spacing: 6) {
+                        Image(systemName: "checkmark.seal.fill")
+                            .font(.system(size: 11))
+                            .foregroundColor(NordTheme.accentGreen(colorScheme))
+                        Text("Configured: \(name)" + (browserDebugPort.map { "  ·  port \($0)" } ?? ""))
+                            .font(.system(size: 12, design: .monospaced))
+                            .foregroundColor(NordTheme.secondaryText(colorScheme))
+                    }
+                }
+
+                Text("Enabling opens a Terminal window with `omnikey grant-browser-access`. Pick a browser and an Omnikey debug profile — the same prompts as the CLI. Disabling clears the saved profile config and removes the auto-launch LaunchAgent.")
+                    .font(.system(size: 11))
+                    .foregroundColor(NordTheme.secondaryText(colorScheme))
+            }
+        }
+    }
+
+    // MARK: - Card chrome
+
+    @ViewBuilder
+    private func settingCard<Content: View>(
+        icon: String,
+        title: String,
+        subtitle: String,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .center, spacing: 8) {
+                Image(systemName: icon)
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundColor(NordTheme.accent(colorScheme))
+                Text(title)
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundColor(NordTheme.primaryText(colorScheme))
+                Spacer()
+            }
+            Text(subtitle)
+                .font(.system(size: 12))
+                .foregroundColor(NordTheme.secondaryText(colorScheme))
+
+            content()
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 12)
+        .background(NordTheme.panelBackground(colorScheme))
+        .cornerRadius(8)
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(NordTheme.border(colorScheme), lineWidth: 1)
+        )
+    }
+
+    // MARK: - Actions
+
+    private func loadSettings() {
+        isLoading = true
+        statusMessage = ""
+        apiClient.fetchAppSettings { result in
+            DispatchQueue.main.async {
+                isLoading = false
+                switch result {
+                case .success(let response):
+                    terminalAccess = response.terminalAccess
+                    webSearchEnabled = response.webSearchEnabled
+                    browserAccessEnabled = response.browserAccessEnabled
+                    browserDebugBrowserName = response.browserDebugBrowserName
+                    browserDebugPort = response.browserDebugPort
+                case .failure(let error):
+                    statusMessage = "Failed to load settings: \(error.localizedDescription)"
+                }
+            }
+        }
+    }
+
+    private func applyTerminalAccess(_ mode: APIClient.TerminalAccessMode) {
+        isLoading = true
+        statusMessage = "Applying terminal access = \(mode.rawValue) — server will restart…"
+        apiClient.updateAppSettings(terminalAccess: mode, webSearchEnabled: nil) { result in
+            DispatchQueue.main.async {
+                switch result {
+                case .success(let resp):
+                    terminalAccess = resp.terminalAccess
+                    statusMessage = "Terminal access set to \(resp.terminalAccess.rawValue). Waiting for daemon restart…"
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) { loadSettings() }
+                case .failure(let error):
+                    isLoading = false
+                    statusMessage = "Failed to apply: \(error.localizedDescription)"
+                }
+            }
+        }
+    }
+
+    private func applyWebSearch(_ enabled: Bool) {
+        isLoading = true
+        statusMessage = "Updating web search — server will restart…"
+        apiClient.updateAppSettings(terminalAccess: nil, webSearchEnabled: enabled) { result in
+            DispatchQueue.main.async {
+                switch result {
+                case .success(let resp):
+                    webSearchEnabled = resp.webSearchEnabled
+                    statusMessage = "Web search \(resp.webSearchEnabled ? "enabled" : "disabled"). Waiting for daemon restart…"
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) { loadSettings() }
+                case .failure(let error):
+                    isLoading = false
+                    statusMessage = "Failed to apply: \(error.localizedDescription)"
+                }
+            }
+        }
+    }
+
+    private func applyBrowserAccess(_ enabled: Bool) {
+        isLoading = true
+        statusMessage = enabled
+            ? "Launching browser-access setup in Terminal…"
+            : "Disabling browser access — server will restart…"
+        apiClient.setBrowserAccessEnabled(enabled) { result in
+            DispatchQueue.main.async {
+                switch result {
+                case .success(let resp):
+                    browserAccessEnabled = resp.browserAccessEnabled
+                    if let message = resp.message, !message.isEmpty {
+                        statusMessage = message
+                    } else {
+                        statusMessage = enabled
+                            ? "Browser access setup started in Terminal."
+                            : "Browser access disabled."
+                    }
+                    // Give the daemon and (when enabling) the Terminal-based
+                    // setup a moment before reloading so the UI reflects the
+                    // updated BROWSER_DEBUG_* values.
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) { loadSettings() }
+                case .failure(let error):
+                    isLoading = false
+                    statusMessage = "Failed to toggle browser access: \(error.localizedDescription)"
+                }
+            }
+        }
+    }
+}

--- a/macOS/Sources/SettingsShell.swift
+++ b/macOS/Sources/SettingsShell.swift
@@ -2,31 +2,34 @@ import AppKit
 import SwiftUI
 
 private enum SettingsTab: String, CaseIterable, Identifiable {
-    case providers, updates, manual
+    case providers, agentAccess, updates, manual
 
     var id: String { rawValue }
 
     var title: String {
         switch self {
-        case .providers: return "AI Providers"
-        case .updates:   return "Check for Updates"
-        case .manual:    return "Manual"
+        case .providers:    return "AI Providers"
+        case .agentAccess:  return "Agent Access"
+        case .updates:      return "Check for Updates"
+        case .manual:       return "Manual"
         }
     }
 
     var iconName: String {
         switch self {
-        case .providers: return "key.fill"
-        case .updates:   return "arrow.down.circle.fill"
-        case .manual:    return "book.fill"
+        case .providers:    return "key.fill"
+        case .agentAccess:  return "lock.shield.fill"
+        case .updates:      return "arrow.down.circle.fill"
+        case .manual:       return "book.fill"
         }
     }
 
     var subtitle: String {
         switch self {
-        case .providers: return "Manage API keys"
-        case .updates:   return "App version & updates"
-        case .manual:    return "Shortcuts & usage"
+        case .providers:    return "Manage API keys"
+        case .agentAccess:  return "Terminal, web & browser"
+        case .updates:      return "App version & updates"
+        case .manual:       return "Shortcuts & usage"
         }
     }
 }
@@ -127,6 +130,8 @@ struct SettingsView: View {
         switch selection {
         case .providers:
             AIProvidersSettingsView()
+        case .agentAccess:
+            AgentAccessSettingsView()
         case .updates:
             UpdatesSettingsView()
         case .manual:

--- a/macOS/build_release_dmg.sh
+++ b/macOS/build_release_dmg.sh
@@ -127,9 +127,9 @@ cat > "${INFO_PLIST}" <<EOF
     <key>CFBundleIdentifier</key>
     <string>${BUNDLE_ID}</string>
     <key>CFBundleVersion</key>
-    <string>40</string>
+    <string>41</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.0.39</string>
+    <string>1.0.40</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
## Summary

Adds a new **Agent Access** tab to the macOS Settings window so users can configure how broad the agent's machine access is from a UI instead of editing `~/.omnikey/config.json` by hand. All three controls follow the same persistence model already established by the AI Providers pane: write to `~/.omnikey/config.json` and schedule a detached `omnikey restart-daemon` so the running process picks the values up.

## Controls added

| Setting | Default | Effect |
| --- | --- | --- |
| **Terminal access** | `Full` | `Full` = unchanged shell tool; `Limited` swaps in a tool description that tells the model to only run read-only inspection commands (and mirrors the same restriction for the gpt-5.5 Responses API path). |
| **Web search** | `Enabled` | When disabled, `buildAvailableTools()` no longer registers `web_search` / `web_fetch`, matching how MCP-only tools are gated elsewhere. |
| **Authenticated browser access** | `Disabled` | Enabling launches `omnikey grant-browser-access` inside a new Terminal window via `osascript` so the existing inquirer prompts (browser pick, profile name, etc.) work unchanged — same UX as the CLI. Disabling clears the saved `BROWSER_DEBUG_*` keys and unloads/removes the macOS LaunchAgent the CLI created. |

## Files changed

**Backend (`api/`):**
- `src/appSettingsRoutes.ts` *(new)* — `GET /api/app-settings`, `PATCH /api/app-settings`, `POST /api/app-settings/browser-access`.
- `src/index.ts` — mounts the new router at `/api/app-settings`.
- `src/config.ts` — adds `terminalAccess`, `webSearchEnabled`, `browserAccessEnabled` plus the `TerminalAccessMode` type.
- `src/agent/utils.ts` — gates web tools on `config.webSearchEnabled`; adds `SHELL_SCRIPT_TOOL_LIMITED`.
- `src/agent/agentServer.ts` — picks the limited shell tool when `terminalAccess === 'limited'`.
- `src/ai-client.ts` — splits `RESPONSES_SHELL_TOOL` into full / limited variants and selects per request based on `config.terminalAccess`.

**macOS app:**
- `Sources/AgentAccessSettingsView.swift` *(new)* — segmented picker + two toggles + confirmation dialogs, sharing chrome conventions with `AIProvidersSettingsView`.
- `Sources/SettingsShell.swift` — new `.agentAccess` tab between Providers and Updates with a shield icon.
- `Sources/APIClient.swift` — adds `TerminalAccessMode`, `fetchAppSettings`, `updateAppSettings`, `setBrowserAccessEnabled`.

## How the browser-access flow works

The CLI flow (`grantBrowserAccess.ts`) is heavily interactive (browser selection, profile management, killing existing browser processes, port allocation, LaunchAgent registration). Reimplementing every prompt in SwiftUI would have been a huge rewrite, so the backend instead spawns the CLI inside a fresh Terminal window via `osascript`:

```text
Settings → Agent Access → toggle on
   ↓
POST /api/app-settings/browser-access {enabled:true}
   ↓
osascript → Terminal.app → node cli/dist/index.js grant-browser-access
```

This is consistent with the "same as daemon restart" intent in the issue — the macOS app delegates to the existing CLI command rather than reimplementing it. Disabling tears down config keys and the LaunchAgent inline (no Terminal needed for the off path).

## Verification

- `yarn build` ✅ (root workspace builds api, telegram, cli; no TS errors)
- `swift build` ✅ in `macOS/` (only pre-existing concurrency warnings unrelated to this PR)
- `yarn workspace omnikey-ai-api test` — 64 passed / 3 failed; the 3 failures are pre-existing on `main` (gpt-5.5 Responses adapter tests, `client.responses.stream` undefined in mock) and not touched by this change.

## Notes & assumptions

- `Limited` terminal access is a **prompt-level** restriction (tool description + instruction wording), not a kernel sandbox — same model the rest of the agent uses to scope behaviour. This is called out explicitly in the tool description and the UI subtitle.
- Disabling browser access keeps the debug profile directory under `~/.omnikey/browser-debug-profiles` so re-enabling does not force the user to sign back into every site.
- The browser-access POST endpoint is currently macOS-only (it relies on Terminal.app + `osascript`); the Windows app will need an equivalent helper before exposing the same toggle.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added terminal access modes (full/limited) to control shell command capabilities
  * Added configurable web search toggle
  * Added authenticated browser access management for macOS users
  * New Agent Access settings pane to configure these capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->