### PR TITLE
fix(session-grouping): correct project identification end-to-end (regex + LLM + cron)

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omnikey-ai-api",
-  "version": "1.6.10",
+  "version": "1.6.11",
   "main": "dist/index.js",
   "description": "Omnikey AI backend API. Use Yarn for install/build/start.",
   "scripts": {

--- a/api/src/__tests__/sessionGrouping.test.ts
+++ b/api/src/__tests__/sessionGrouping.test.ts
@@ -374,6 +374,24 @@ describe('production-observed regressions', () => {
     const got = extractProjectPath(inputs);
     expect(got).toBe('/Users/me/NewProj');
   });
+
+  it('expands ~/ to the current HOME before extracting paths', () => {
+    // Production sessions referenced things like "~/work/coderabbitai/grafana".
+    // Without tilde expansion the regex captures only "/work/coderabbitai/grafana"
+    // and we accept /work as a top-level root — that produced descriptions
+    // storing "Project root: /work/coderabbitai/..." which is wrong.
+    const originalHome = process.env.HOME;
+    process.env.HOME = '/Users/me';
+    try {
+      const got = extractProjectPath([
+        'edit ~/work/coderabbitai/grafana/src/x.ts',
+        'and ~/work/coderabbitai/grafana/package.json',
+      ]);
+      expect(got).toBe('/Users/me/work/coderabbitai/grafana');
+    } finally {
+      process.env.HOME = originalHome;
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/api/src/__tests__/sessionGrouping.test.ts
+++ b/api/src/__tests__/sessionGrouping.test.ts
@@ -1011,3 +1011,68 @@ describe('refreshGroupDescription ancestor/descendant collapse', () => {
     expect(onlyCall[0]).not.toHaveProperty('groupName');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Local-path allow-list + URL pre-stripping — only paths that look like real
+// local-computer paths are considered project roots. Everything URL-shaped is
+// stripped before path extraction runs.
+// ---------------------------------------------------------------------------
+describe('local-path-only filter', () => {
+  const { extractProjectPath, trimToProjectRoot, extractAllProjectRoots } = __testing__;
+
+  it('strips full URLs (http, https, ftp, file, ws, ssh, git+...) before path extraction', () => {
+    // None of these URL substrings should contribute a project root candidate.
+    const inputs = [
+      'see https://github.com/coderabbitai/grafana/pull/220',
+      'and http://localhost:5173/dashboard/summary',
+      'plus ftp://example.com/files/x.zip',
+      'also file:///etc/hosts',
+      'streaming wss://realtime.example.com/v1/events',
+      'and ssh://git@example.com/owner/repo.git',
+      'and git+https://github.com/foo/bar.git',
+    ];
+    expect(extractProjectPath(inputs)).toBeNull();
+    expect(extractAllProjectRoots(inputs)).toEqual([]);
+  });
+
+  it('strips scheme-relative URLs (//host.tld/path)', () => {
+    expect(extractProjectPath(['see //example.com/path/here'])).toBeNull();
+  });
+
+  it('strips bare host.tld/path URLs without a scheme', () => {
+    expect(extractProjectPath(['github.com/coderabbitai/grafana/pull/220'])).toBeNull();
+    expect(extractProjectPath(['localhost:5173/dashboard/summary'])).toBeNull();
+  });
+
+  it('strips git@host:owner/repo and mailto: addresses', () => {
+    expect(extractProjectPath(['cloned git@github.com:owner/repo.git'])).toBeNull();
+    expect(extractProjectPath(['email mailto:foo@example.com please'])).toBeNull();
+  });
+
+  it('extracts only the real local path when a URL and a path appear together', () => {
+    const got = extractProjectPath([
+      'see https://github.com/me/Repo and edit /Users/me/Real/src/x.ts',
+      'and /Users/me/Real/package.json',
+    ]);
+    expect(got).toBe('/Users/me/Real');
+  });
+
+  it('rejects paths that do not start with a recognised local prefix', () => {
+    // These look like absolute paths to a naive regex but are actually URL
+    // route fragments or top-level pseudo-roots that should never be a
+    // project root in their own right.
+    expect(trimToProjectRoot('/db-api-server/src/routers/pending-learnings')).toBeNull();
+    expect(trimToProjectRoot('/src/chat')).toBeNull();
+    expect(trimToProjectRoot('/work/coderabbitai/mono')).toBeNull();
+    expect(trimToProjectRoot('/api/v1/users')).toBeNull();
+  });
+
+  it('accepts the standard local-computer prefixes', () => {
+    expect(trimToProjectRoot('/Users/me/MyApp/src/x.ts')).toBe('/Users/me/MyApp');
+    expect(trimToProjectRoot('/home/alice/MyApp/src/x.ts')).toBe('/home/alice/MyApp');
+    expect(trimToProjectRoot('/opt/myapp/src/x.ts')).toBe('/opt/myapp');
+    expect(trimToProjectRoot('/Volumes/Data/MyRepo/src/x.ts')).toBe('/Volumes/Data/MyRepo');
+    expect(trimToProjectRoot('/mnt/drive/MyApp/src/x.ts')).toBe('/mnt/drive/MyApp');
+    expect(trimToProjectRoot('/private/Users/me/MyApp/src/x.ts')).toBe('/private/Users/me/MyApp');
+  });
+});

--- a/api/src/__tests__/sessionGrouping.test.ts
+++ b/api/src/__tests__/sessionGrouping.test.ts
@@ -53,7 +53,14 @@ const { extractUserInputs, extractProjectPath, stripInjectedWrappers, trimToProj
 // stripInjectedWrappers
 // ---------------------------------------------------------------------------
 describe('stripInjectedWrappers', () => {
-  it('removes <project_context> blocks injected by the agent server', () => {
+  it('strips <project_context> tags but preserves the Project root: path as a [context root] line', () => {
+    // The <project_context> block must not be re-fed verbatim (its prose
+    // about purpose/language would bias the LLM), but its declared project
+    // root is the only deterministic signal we have when the user types a
+    // path-free message like "continue" or "what about the cron?". So we
+    // keep the path as a single tagged line that contributes exactly one
+    // vote to extractProjectPath but never appears in the LLM prompt as if
+    // the user typed it.
     const input = `<project_context name="OmniKey AI">
 Project root: /Users/me/OmniKey-AI.
 </project_context>
@@ -61,8 +68,16 @@ Project root: /Users/me/OmniKey-AI.
 Hey, please look at /Users/me/NewProj/src/index.ts`;
     const out = stripInjectedWrappers(input);
     expect(out).not.toContain('project_context');
-    expect(out).not.toContain('/Users/me/OmniKey-AI');
+    expect(out).not.toContain('Project root:');
+    expect(out).toContain('[context root] /Users/me/OmniKey-AI');
     expect(out).toContain('/Users/me/NewProj/src/index.ts');
+  });
+
+  it('drops the context-root line entirely when the block has no Project root: sentence', () => {
+    const out = stripInjectedWrappers(
+      '<project_context name="Misc">Just some prose.</project_context>\nhello',
+    );
+    expect(out).toBe('hello');
   });
 
   it('removes <stored_instructions> blocks', () => {
@@ -108,12 +123,11 @@ describe('extractUserInputs', () => {
     expect(extractUserInputs(history)).toEqual(['fix /Users/me/AppA/index.ts']);
   });
 
-  it('strips <project_context> from inside <user_input> so old paths do not leak', () => {
-    // This is the regression: on turn 2 of a grouped session, the server
-    // prepends a <project_context> block (with the OLD group's path) inside
-    // <user_input>. extractUserInputs must not treat that injected text as
-    // user-typed content, otherwise the classifier keeps re-picking the old
-    // group.
+  it('extracts <project_context> Project root: as a low-weight [context root] line', () => {
+    // On turn 2 of a grouped session, the server prepends a <project_context>
+    // block (with the previously stored group's path) inside <user_input>.
+    // We keep that path as a low-weight "[context root]" line — one vote —
+    // and let any path the user actually types this turn outvote it.
     const history = JSON.stringify([
       {
         role: 'user',
@@ -132,7 +146,7 @@ describe('extractUserInputs', () => {
     const inputs = extractUserInputs(history);
     expect(inputs).toHaveLength(1);
     expect(inputs[0]).not.toContain('project_context');
-    expect(inputs[0]).not.toContain('/Users/me/OldParent');
+    expect(inputs[0]).toContain('[context root] /Users/me/OldParent');
     expect(inputs[0]).toContain('/Users/me/NewProj');
   });
 
@@ -280,6 +294,89 @@ describe('extractProjectPath', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Production-observed bug scenarios — these mirror the actual session
+// histories we found in sqlite after the cron rewrote descriptions with
+// hallucinated paths. They pin two specific protections:
+//   (a) URL-shaped "absolute paths" never become a project root.
+//   (b) When the user's typed turn has no path, the <project_context>
+//       fallback prevents the LLM from being fed an empty path slate.
+// ---------------------------------------------------------------------------
+describe('production-observed regressions', () => {
+  const { trimToProjectRoot, extractProjectPath, extractUserInputs } = __testing__;
+
+  it('rejects URL-shaped pseudo-paths (github.com, linear.app, console.cloud.google.com)', () => {
+    expect(trimToProjectRoot('/github.com/coderabbitai/grafana/pull/220')).toBeNull();
+    expect(trimToProjectRoot('/linear.app/coderabbit/issue/REV-19/programmable-access')).toBeNull();
+    expect(
+      trimToProjectRoot('/console.cloud.google.com/run/worker-pools/details/us-central1'),
+    ).toBeNull();
+    expect(trimToProjectRoot('/localhost:5173/dashboard/summary')).toBeNull();
+    expect(trimToProjectRoot('/apps.apple.com/ca/app/bhabi/id6475659322')).toBeNull();
+  });
+
+  it('still accepts legitimate filesystem paths next to URL-shaped tokens', () => {
+    // Mixed text with both a URL-shaped pseudo-path and a real path — only
+    // the real path should win.
+    const got = extractProjectPath([
+      'see https://github.com/coderabbitai/grafana/pull/220 (rendered as /github.com/coderabbitai/grafana/pull/220)',
+      'and edit /Users/me/RealRepo/src/main.ts',
+      'and /Users/me/RealRepo/package.json',
+    ]);
+    expect(got).toBe('/Users/me/RealRepo');
+  });
+
+  it('falls back to <project_context> path when the user types nothing path-shaped', () => {
+    // Simulates: turn 1 grouped the session under "My App" with stored path
+    // /Users/me/MyApp. On turn 2 the user types a path-free question like
+    // "continue working". Without the fallback, extractProjectPath would
+    // return null and the LLM would be free to invent. With the fallback,
+    // it returns the previously stored path so safety nets can compare.
+    const history = JSON.stringify([
+      {
+        role: 'user',
+        content: [
+          '<user_input>',
+          '<project_context name="My App">',
+          'Project root: /Users/me/MyApp. Purpose: x. Primary language: TypeScript.',
+          '</project_context>',
+          '',
+          'continue working on the task',
+          '</user_input>',
+        ].join('\n'),
+      },
+    ]);
+    const inputs = extractUserInputs(history);
+    const got = extractProjectPath(inputs);
+    expect(got).toBe('/Users/me/MyApp');
+  });
+
+  it('user-typed path still beats a stale <project_context> fallback path', () => {
+    // The original parent/child regression, expressed at the extractProjectPath
+    // layer end-to-end: <project_context> claims /Users/me/OldParent (one
+    // [context root] vote), user types /Users/me/NewProj three times.
+    const history = JSON.stringify([
+      {
+        role: 'user',
+        content: [
+          '<user_input>',
+          '<project_context name="OldParent">',
+          'Project root: /Users/me/OldParent. Purpose: x. Primary language: y.',
+          '</project_context>',
+          '',
+          'fix /Users/me/NewProj/a.ts',
+          'and /Users/me/NewProj/b.ts',
+          'and /Users/me/NewProj/c.ts',
+          '</user_input>',
+        ].join('\n'),
+      },
+    ]);
+    const inputs = extractUserInputs(history);
+    const got = extractProjectPath(inputs);
+    expect(got).toBe('/Users/me/NewProj');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // extractStoredProjectPath
 // ---------------------------------------------------------------------------
 describe('extractStoredProjectPath', () => {
@@ -310,6 +407,22 @@ describe('extractStoredProjectPath', () => {
     expect(
       extractStoredProjectPath('project root: /opt/thing. Purpose: x. Primary language: Go.'),
     ).toBe('/opt/thing');
+  });
+
+  it('returns null when the stored "path" is actually a URL', () => {
+    // Existing descriptions in production were written before URL rejection.
+    // We must treat them as "no stored path" so the LLM gets a chance to
+    // rewrite the description with a real root instead of locking the
+    // session forever to a bad URL-shaped pseudo-root.
+    expect(
+      extractStoredProjectPath(
+        'Project root: /github.com/coderabbitai/grafana/pull/220. Purpose: x.',
+      ),
+    ).toBeNull();
+    expect(
+      extractStoredProjectPath('Project root: /linear.app/coderabbit/issue/REV-19. Purpose: x.'),
+    ).toBeNull();
+    expect(extractStoredProjectPath('Project root: /localhost:5173/dashboard.')).toBeNull();
   });
 });
 

--- a/api/src/__tests__/sessionGrouping.test.ts
+++ b/api/src/__tests__/sessionGrouping.test.ts
@@ -740,3 +740,274 @@ describe('refreshGroupDescription', () => {
     expect(lastRefreshedAt.get('sub-1::My App')).toBeInstanceOf(Date);
   });
 });
+
+// ---------------------------------------------------------------------------
+// truncateOnSentenceBoundary
+// ---------------------------------------------------------------------------
+describe('truncateOnSentenceBoundary', () => {
+  const { truncateOnSentenceBoundary } = __testing__;
+
+  it('returns the input unchanged when shorter than the limit', () => {
+    expect(truncateOnSentenceBoundary('Hi.', 100)).toBe('Hi.');
+  });
+
+  it('truncates on the last sentence boundary within the budget', () => {
+    const input =
+      'Project root: /Users/me/MyApp. Purpose: build a thing. Primary language: TypeScript. Recent focus: refactoring tests.';
+    const got = truncateOnSentenceBoundary(input, 80);
+    // Must end with a full sentence; must not contain a trailing partial word.
+    expect(got.endsWith('.')).toBe(true);
+    expect(got.length).toBeLessThanOrEqual(80);
+    expect(got).toContain('Project root: /Users/me/MyApp.');
+  });
+
+  it('never cuts a word in half', () => {
+    const input = 'Primary language is TypeScriptAndJavaScript and we love it';
+    const got = truncateOnSentenceBoundary(input, 30);
+    // Either it ends at a word boundary OR it ended with the synthetic period.
+    expect(got).not.toMatch(/[A-Za-z]$/);
+  });
+
+  it('appends a period when there was no sentence to land on', () => {
+    const input = 'no terminator here just a long string of words without dots';
+    const got = truncateOnSentenceBoundary(input, 25);
+    expect(got.endsWith('.')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractAllProjectRoots — surface every distinct root referenced in the inputs
+// ---------------------------------------------------------------------------
+describe('extractAllProjectRoots', () => {
+  const { extractAllProjectRoots } = __testing__;
+
+  it('returns one entry per distinct normalised root, ordered by votes', () => {
+    const got = extractAllProjectRoots([
+      'fix /Users/me/AppA/src/a.ts',
+      'fix /Users/me/AppA/src/b.ts',
+      'fix /Users/me/AppA/package.json',
+      'and one file in /Users/me/AppB/main.go',
+    ]);
+    expect(got).toEqual([
+      { root: '/Users/me/AppA', votes: 3 },
+      { root: '/Users/me/AppB', votes: 1 },
+    ]);
+  });
+
+  it('returns [] when no real paths are referenced', () => {
+    expect(extractAllProjectRoots(['hello world'])).toEqual([]);
+  });
+
+  it('ignores URL-shaped pseudo-paths', () => {
+    const got = extractAllProjectRoots([
+      'see /github.com/foo/bar/pull/1',
+      'and edit /Users/me/Real/src/x.ts',
+    ]);
+    expect(got).toEqual([{ root: '/Users/me/Real', votes: 1 }]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractKeySubdirectories — the directories worked on inside one project root
+// ---------------------------------------------------------------------------
+describe('extractKeySubdirectories', () => {
+  const { extractKeySubdirectories } = __testing__;
+
+  it('returns the most-referenced subdirs under the given root, ordered by votes', () => {
+    const got = extractKeySubdirectories(
+      [
+        'fix /Users/me/Repo/api/src/agent/x.ts',
+        'fix /Users/me/Repo/api/src/agent/y.ts',
+        'fix /Users/me/Repo/api/src/routes/z.ts',
+        'fix /Users/me/Repo/cli/main.ts',
+      ],
+      '/Users/me/Repo',
+      4,
+    );
+    // /Users/me/Repo/api appears in three of the four file paths, so it
+    // wins the top spot. The cli sub-dir only appears once, but with a
+    // limit of 4 it should still surface alongside the api sub-tree.
+    expect(got[0]).toBe('/Users/me/Repo/api');
+    expect(got).toContain('/Users/me/Repo/cli');
+  });
+
+  it('returns [] when no paths are under the root', () => {
+    const got = extractKeySubdirectories(['fix /Users/me/OtherRepo/main.ts'], '/Users/me/Repo', 3);
+    expect(got).toEqual([]);
+  });
+
+  it('respects the limit', () => {
+    const got = extractKeySubdirectories(
+      ['/Users/me/Repo/a/x.ts /Users/me/Repo/b/x.ts /Users/me/Repo/c/x.ts /Users/me/Repo/d/x.ts'],
+      '/Users/me/Repo',
+      2,
+    );
+    expect(got).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// refreshGroupDescription — group splitting (one project = one group)
+// ---------------------------------------------------------------------------
+describe('refreshGroupDescription split behaviour', () => {
+  const { refreshGroupDescription, lastRefreshedAt } = __testing__;
+
+  async function getMocks() {
+    const aiClientMod = await import('../ai-client');
+    const agentSessionMod = await import('../models/agentSession');
+    return {
+      complete: (aiClientMod as unknown as { aiClient: { complete: ReturnType<typeof vi.fn> } })
+        .aiClient.complete,
+      findAll: (
+        agentSessionMod as unknown as { AgentSession: { findAll: ReturnType<typeof vi.fn> } }
+      ).AgentSession.findAll,
+      findOne: (
+        agentSessionMod as unknown as { AgentSession: { findOne: ReturnType<typeof vi.fn> } }
+      ).AgentSession.findOne,
+      update: (agentSessionMod as unknown as { AgentSession: { update: ReturnType<typeof vi.fn> } })
+        .AgentSession.update,
+    };
+  }
+
+  function userTurn(content: string) {
+    return { role: 'user', content: `<user_input>${content}</user_input>` };
+  }
+
+  it('demotes sessions whose dominant root differs from the group dominant root', async () => {
+    const { findOne, findAll, complete, update } = await getMocks();
+    lastRefreshedAt.clear();
+    findOne.mockResolvedValueOnce({ lastActiveAt: new Date('2030-01-02T00:00:00Z') });
+    findAll.mockResolvedValueOnce([
+      // 3 sessions belong to /Users/me/AppA — the dominant root.
+      {
+        id: 'a-1',
+        historyJson: JSON.stringify([userTurn('edit /Users/me/AppA/src/x.ts')]),
+      },
+      {
+        id: 'a-2',
+        historyJson: JSON.stringify([userTurn('fix /Users/me/AppA/y.ts')]),
+      },
+      {
+        id: 'a-3',
+        historyJson: JSON.stringify([userTurn('check /Users/me/AppA/z.ts')]),
+      },
+      // 1 polluting session in /Users/me/AppB — must be demoted.
+      {
+        id: 'b-1',
+        historyJson: JSON.stringify([userTurn('edit /Users/me/AppB/main.ts')]),
+      },
+    ]);
+    complete.mockResolvedValueOnce({
+      content: JSON.stringify({
+        groupDescription: 'Project root: /Users/me/AppA. Purpose: x. Primary language: TypeScript.',
+      }),
+    });
+    update.mockClear();
+
+    await refreshGroupDescription('sub-1', 'My App', 'old desc');
+
+    // First update call: clears groupName for the straggler 'b-1'.
+    expect(update).toHaveBeenCalledTimes(2);
+    const firstUpdate = update.mock.calls[0];
+    expect(firstUpdate[0]).toEqual({ groupName: null, groupDescription: null });
+    // The where clause should target only the straggler id.
+    const stragglerWhere = firstUpdate[1].where;
+    const idClause = stragglerWhere.id;
+    const ids = idClause[Object.getOwnPropertySymbols(idClause)[0]] ?? idClause['in'];
+    expect(ids).toEqual(['b-1']);
+
+    // Second update: writes the new description for the surviving group.
+    const secondUpdate = update.mock.calls[1];
+    expect(secondUpdate[0].groupDescription).toContain('/Users/me/AppA');
+    expect(secondUpdate[0].groupDescription).not.toContain('/Users/me/AppB');
+  });
+
+  it('does NOT demote sessions when they all share the same dominant root', async () => {
+    const { findOne, findAll, complete, update } = await getMocks();
+    lastRefreshedAt.clear();
+    findOne.mockResolvedValueOnce({ lastActiveAt: new Date('2030-02-02T00:00:00Z') });
+    findAll.mockResolvedValueOnce([
+      {
+        id: 'a-1',
+        historyJson: JSON.stringify([userTurn('edit /Users/me/AppA/src/x.ts')]),
+      },
+      {
+        id: 'a-2',
+        historyJson: JSON.stringify([userTurn('fix /Users/me/AppA/y.ts')]),
+      },
+    ]);
+    complete.mockResolvedValueOnce({
+      content: JSON.stringify({
+        groupDescription: 'Project root: /Users/me/AppA. Purpose: x. Primary language: TypeScript.',
+      }),
+    });
+    update.mockClear();
+
+    await refreshGroupDescription('sub-1', 'AppA', 'old desc');
+
+    // Only the description-update call should fire — no demotion update.
+    expect(update).toHaveBeenCalledTimes(1);
+    const onlyCall = update.mock.calls[0];
+    expect(onlyCall[0]).toHaveProperty('groupDescription');
+    expect(onlyCall[0]).not.toHaveProperty('groupName');
+  });
+});
+
+describe('refreshGroupDescription ancestor/descendant collapse', () => {
+  const { refreshGroupDescription, lastRefreshedAt } = __testing__;
+
+  async function getMocks() {
+    const aiClientMod = await import('../ai-client');
+    const agentSessionMod = await import('../models/agentSession');
+    return {
+      complete: (aiClientMod as unknown as { aiClient: { complete: ReturnType<typeof vi.fn> } })
+        .aiClient.complete,
+      findAll: (
+        agentSessionMod as unknown as { AgentSession: { findAll: ReturnType<typeof vi.fn> } }
+      ).AgentSession.findAll,
+      findOne: (
+        agentSessionMod as unknown as { AgentSession: { findOne: ReturnType<typeof vi.fn> } }
+      ).AgentSession.findOne,
+      update: (agentSessionMod as unknown as { AgentSession: { update: ReturnType<typeof vi.fn> } })
+        .AgentSession.update,
+    };
+  }
+
+  function userTurn(content: string) {
+    return { role: 'user', content: `<user_input>${content}</user_input>` };
+  }
+
+  it('does NOT split when sessions reference the project at different depths', async () => {
+    // Two sessions in the same project — one only mentions files at the
+    // repo root, the other only mentions files inside the api/ subdir.
+    // Before the ancestor/descendant collapse this group used to get split
+    // into two on every tick, demoting half the sessions for no reason.
+    const { findOne, findAll, complete, update } = await getMocks();
+    lastRefreshedAt.clear();
+    findOne.mockResolvedValueOnce({ lastActiveAt: new Date('2030-03-03T00:00:00Z') });
+    findAll.mockResolvedValueOnce([
+      {
+        id: 'a-1',
+        historyJson: JSON.stringify([userTurn('edit /Users/me/Repo/README.md')]),
+      },
+      {
+        id: 'a-2',
+        historyJson: JSON.stringify([userTurn('fix /Users/me/Repo/api/src/agent/x.ts')]),
+      },
+    ]);
+    complete.mockResolvedValueOnce({
+      content: JSON.stringify({
+        groupDescription: 'Project root: /Users/me/Repo. Purpose: x. Primary language: TypeScript.',
+      }),
+    });
+    update.mockClear();
+
+    await refreshGroupDescription('sub-1', 'Repo', 'old desc');
+
+    // Only the description-update call should fire — no demotion update.
+    expect(update).toHaveBeenCalledTimes(1);
+    const onlyCall = update.mock.calls[0];
+    expect(onlyCall[0]).toHaveProperty('groupDescription');
+    expect(onlyCall[0]).not.toHaveProperty('groupName');
+  });
+});

--- a/api/src/__tests__/sessionGrouping.test.ts
+++ b/api/src/__tests__/sessionGrouping.test.ts
@@ -278,3 +278,195 @@ describe('extractProjectPath', () => {
     expect(got).toBe('/Users/me/OmniKey-AI/cli');
   });
 });
+
+// ---------------------------------------------------------------------------
+// extractStoredProjectPath
+// ---------------------------------------------------------------------------
+describe('extractStoredProjectPath', () => {
+  const { extractStoredProjectPath } = __testing__;
+
+  it('returns null for empty / missing descriptions', () => {
+    expect(extractStoredProjectPath(null)).toBeNull();
+    expect(extractStoredProjectPath(undefined)).toBeNull();
+    expect(extractStoredProjectPath('')).toBeNull();
+  });
+
+  it('returns null when description has no "Project root:" sentence', () => {
+    expect(extractStoredProjectPath('Some general group about chatting.')).toBeNull();
+  });
+
+  it('extracts an absolute path from a standard description', () => {
+    const desc =
+      'Project root: /Users/me/MyApp. Purpose: build a thing. Primary language: TypeScript.';
+    expect(extractStoredProjectPath(desc)).toBe('/Users/me/MyApp');
+  });
+
+  it('walks the extracted path up through src/ subdirs', () => {
+    const desc = 'Project root: /Users/me/MyApp/src. Purpose: thing. Primary language: TS.';
+    expect(extractStoredProjectPath(desc)).toBe('/Users/me/MyApp');
+  });
+
+  it('is case-insensitive on the label', () => {
+    expect(
+      extractStoredProjectPath('project root: /opt/thing. Purpose: x. Primary language: Go.'),
+    ).toBe('/opt/thing');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findGroupByExactPath
+// ---------------------------------------------------------------------------
+describe('findGroupByExactPath', () => {
+  const { findGroupByExactPath } = __testing__;
+
+  const groups = [
+    {
+      groupName: 'OmniKey AI',
+      groupDescription:
+        'Project root: /Users/me/OmniKey-AI. Purpose: parent. Primary language: TypeScript.',
+    },
+    {
+      groupName: 'OmniKey CLI',
+      groupDescription:
+        'Project root: /Users/me/OmniKey-AI/cli. Purpose: cli. Primary language: TypeScript.',
+    },
+    {
+      groupName: 'General',
+      groupDescription:
+        'Project root: not specified. Purpose: misc. Primary language: not applicable.',
+    },
+  ];
+
+  it('returns null when currentPath is null', () => {
+    expect(findGroupByExactPath(null, groups)).toBeNull();
+  });
+
+  it('returns the group whose stored path matches exactly', () => {
+    const got = findGroupByExactPath('/Users/me/OmniKey-AI/cli', groups);
+    expect(got?.groupName).toBe('OmniKey CLI');
+  });
+
+  it('does NOT return the ancestor group when current is a child', () => {
+    // The original regression: matching /Users/me/OmniKey-AI/cli against the
+    // OmniKey-AI parent group must be a miss, not a hit.
+    const got = findGroupByExactPath('/Users/me/OmniKey-AI/cli/src/x.ts', [groups[0]]);
+    expect(got).toBeNull();
+  });
+
+  it('returns null when no stored path matches', () => {
+    expect(findGroupByExactPath('/Users/me/Unrelated', groups)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyGroup (LLM pipeline)
+// ---------------------------------------------------------------------------
+describe('classifyGroup', () => {
+  const { classifyGroup } = __testing__;
+
+  // Helper to grab the mocked aiClient.complete and configure it per test.
+  // The module is mocked at the top of this file, so we reach into the mock
+  // dynamically here to avoid a stale reference across describe blocks.
+  async function withMockedLLM<T>(
+    response: { groupName: string; groupDescription: string },
+    run: () => Promise<T>,
+  ): Promise<T> {
+    const aiClientMod = await import('../ai-client');
+    const complete = (
+      aiClientMod as unknown as { aiClient: { complete: ReturnType<typeof vi.fn> } }
+    ).aiClient.complete;
+    complete.mockResolvedValueOnce({ content: JSON.stringify(response) });
+    return run();
+  }
+
+  it('short-circuits on exact path match without calling the LLM', async () => {
+    const aiClientMod = await import('../ai-client');
+    const complete = (
+      aiClientMod as unknown as { aiClient: { complete: ReturnType<typeof vi.fn> } }
+    ).aiClient.complete;
+    complete.mockClear();
+
+    const existing = [
+      {
+        groupName: 'My App',
+        groupDescription:
+          'Project root: /Users/me/MyApp. Purpose: ship it. Primary language: TypeScript.',
+      },
+    ];
+    const inputs = ['fix /Users/me/MyApp/src/index.ts'];
+
+    const result = await classifyGroup(inputs, existing);
+    expect(result?.groupName).toBe('My App');
+    expect(result?.groupDescription).toContain('/Users/me/MyApp');
+    expect(complete).not.toHaveBeenCalled();
+  });
+
+  it('does NOT short-circuit to the parent project when user is in a child', async () => {
+    // The original user-reported bug. Parent group exists with root
+    // /Users/me/Repo. User is in /Users/me/Repo/cli. The LLM should be
+    // consulted (no exact-path match) and must NOT re-use the parent's name.
+    const existing = [
+      {
+        groupName: 'Repo',
+        groupDescription:
+          'Project root: /Users/me/Repo. Purpose: parent. Primary language: TypeScript.',
+      },
+    ];
+    const inputs = ['edit /Users/me/Repo/cli/src/main.ts', 'and /Users/me/Repo/cli/package.json'];
+
+    const result = await withMockedLLM(
+      // Even if the LLM hallucinated the parent name, the post-validation
+      // step should reject it because stored path != current path.
+      {
+        groupName: 'Repo',
+        groupDescription:
+          'Project root: /Users/me/Repo/cli. Purpose: cli. Primary language: TypeScript.',
+      },
+      () => classifyGroup(inputs, existing),
+    );
+
+    expect(result?.groupName).not.toBe('Repo');
+    // The derived name should come from the deepest path segment.
+    expect(result?.groupName?.toLowerCase()).toContain('cli');
+    expect(result?.groupDescription).toContain('/Users/me/Repo/cli');
+    expect(result?.groupDescription).not.toMatch(/Project root:\s*\/Users\/me\/Repo\b(?!\/cli)/);
+  });
+
+  it('overrides LLM choice with exact-path match to a different existing group', async () => {
+    // The LLM invents a fresh name ("Brand New") but the deterministic path
+    // already belongs to an existing group. Path equality must win.
+    const existing = [
+      {
+        groupName: 'Canonical Name',
+        groupDescription:
+          'Project root: /Users/me/Real. Purpose: thing. Primary language: TypeScript.',
+      },
+    ];
+    const inputs = ['fix /Users/me/Real/src/a.ts', 'and /Users/me/Real/src/b.ts'];
+
+    // Because the exact-path short-circuit fires BEFORE the LLM, this test
+    // also implicitly proves the short-circuit beats LLM hallucination.
+    const result = await classifyGroup(inputs, existing);
+    expect(result?.groupName).toBe('Canonical Name');
+  });
+
+  it('replaces a hallucinated path in the LLM description with the extracted path', async () => {
+    const inputs = ['work in /Users/me/Actual/src/index.ts'];
+    const result = await withMockedLLM(
+      {
+        groupName: 'Actual',
+        groupDescription:
+          'Project root: /Users/me/SomethingElse. Purpose: x. Primary language: TypeScript.',
+      },
+      () => classifyGroup(inputs, []),
+    );
+
+    expect(result?.groupDescription).toContain('/Users/me/Actual');
+    expect(result?.groupDescription).not.toContain('/Users/me/SomethingElse');
+  });
+
+  it('returns null when there are no user inputs', async () => {
+    const result = await classifyGroup([], []);
+    expect(result).toBeNull();
+  });
+});

--- a/api/src/__tests__/sessionGrouping.test.ts
+++ b/api/src/__tests__/sessionGrouping.test.ts
@@ -389,7 +389,12 @@ describe('production-observed regressions', () => {
       ]);
       expect(got).toBe('/Users/me/work/coderabbitai/grafana');
     } finally {
-      process.env.HOME = originalHome;
+      // Node's process.env coerces every assignment to a string, so writing
+      // back an undefined originalHome would set HOME to the literal
+      // 'undefined'. Delete the key when it was unset to genuinely restore
+      // the original state.
+      if (originalHome === undefined) delete process.env.HOME;
+      else process.env.HOME = originalHome;
     }
   });
 });
@@ -1074,5 +1079,66 @@ describe('local-path-only filter', () => {
     expect(trimToProjectRoot('/Volumes/Data/MyRepo/src/x.ts')).toBe('/Volumes/Data/MyRepo');
     expect(trimToProjectRoot('/mnt/drive/MyApp/src/x.ts')).toBe('/mnt/drive/MyApp');
     expect(trimToProjectRoot('/private/Users/me/MyApp/src/x.ts')).toBe('/private/Users/me/MyApp');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CodeRabbit review follow-ups. These pin two regressions the bot caught:
+//   1) the [context root] fallback used to be sliced off the end of long
+//      user turns by the 400-char truncation in extractUserInputs;
+//   2) the path-extraction regex used to cap at 6 trailing segments, so deep
+//      monorepo paths got split into two halves and the shallower half
+//      ("/.../packages") won the project-root vote.
+// ---------------------------------------------------------------------------
+describe('CodeRabbit follow-ups', () => {
+  const { extractUserInputs, extractProjectPath, trimToProjectRoot } = __testing__;
+
+  it('preserves the [context root] fallback even when the user body is longer than the 400-char truncation budget', () => {
+    // 600 chars of path-free prose followed by no typed path; the only path
+    // signal is the <project_context> root. The cap on the user body must
+    // be applied to the body alone so the appended fallback line survives.
+    const longProse = 'a'.repeat(600);
+    const history = JSON.stringify([
+      {
+        role: 'user',
+        content: [
+          '<user_input>',
+          '<project_context name="My App">',
+          'Project root: /Users/me/MyApp. Purpose: x. Primary language: TypeScript.',
+          '</project_context>',
+          '',
+          longProse,
+          '</user_input>',
+        ].join('\n'),
+      },
+    ]);
+
+    const inputs = extractUserInputs(history);
+    expect(inputs).toHaveLength(1);
+    expect(inputs[0]).toContain('[context root] /Users/me/MyApp');
+    // And the fallback still drives the deterministic extraction.
+    expect(extractProjectPath(inputs)).toBe('/Users/me/MyApp');
+  });
+
+  it('captures full deep monorepo paths without truncating segments', () => {
+    // The path here has 10 segments after the leading slash; pre-fix the
+    // regex capped at 6 and we ended up classifying the project as
+    // /Users/me/Documents/projects/org/monorepo/packages (the wrong root).
+    const got = trimToProjectRoot(
+      '/Users/me/Documents/projects/org/monorepo/packages/api/src/index.ts',
+    );
+    // With the home-container chain (Documents, projects) skipped, "org" is
+    // the first project-eligible segment. With src/index.ts stripped and
+    // src walked up, we expect the deepest meaningful root the matcher
+    // can find.
+    expect(got).toBe('/Users/me/Documents/projects/org/monorepo/packages/api');
+  });
+
+  it('extracts the deep root end-to-end from realistic monorepo input', () => {
+    const got = extractProjectPath([
+      'fix /Users/me/Documents/projects/org/monorepo/packages/api/src/index.ts',
+      'and /Users/me/Documents/projects/org/monorepo/packages/api/src/util.ts',
+    ]);
+    expect(got).toBe('/Users/me/Documents/projects/org/monorepo/packages/api');
   });
 });

--- a/api/src/__tests__/sessionGrouping.test.ts
+++ b/api/src/__tests__/sessionGrouping.test.ts
@@ -470,3 +470,142 @@ describe('classifyGroup', () => {
     expect(result).toBeNull();
   });
 });
+
+// ---------------------------------------------------------------------------
+// runWithConcurrency
+// ---------------------------------------------------------------------------
+describe('runWithConcurrency', () => {
+  const { runWithConcurrency } = __testing__;
+
+  it('runs every item exactly once', async () => {
+    const seen: number[] = [];
+    await runWithConcurrency([1, 2, 3, 4, 5], 2, async (n) => {
+      seen.push(n);
+    });
+    expect(seen.sort()).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('respects the concurrency limit', async () => {
+    let active = 0;
+    let peak = 0;
+    await runWithConcurrency([1, 2, 3, 4, 5, 6, 7, 8], 3, async () => {
+      active++;
+      peak = Math.max(peak, active);
+      await new Promise((r) => setTimeout(r, 5));
+      active--;
+    });
+    expect(peak).toBeLessThanOrEqual(3);
+  });
+
+  it('continues draining the queue when one item throws', async () => {
+    const seen: number[] = [];
+    await runWithConcurrency([1, 2, 3], 2, async (n) => {
+      if (n === 2) throw new Error('boom');
+      seen.push(n);
+    });
+    expect(seen.sort()).toEqual([1, 3]);
+  });
+
+  it('treats a concurrency limit < 1 as 1', async () => {
+    const seen: number[] = [];
+    await runWithConcurrency([1, 2, 3], 0, async (n) => {
+      seen.push(n);
+    });
+    expect(seen.sort()).toEqual([1, 2, 3]);
+  });
+
+  it('returns immediately for an empty input', async () => {
+    let called = false;
+    await runWithConcurrency([], 5, async () => {
+      called = true;
+    });
+    expect(called).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// refreshGroupDescription — skip-if-idle gating
+// ---------------------------------------------------------------------------
+describe('refreshGroupDescription', () => {
+  const { refreshGroupDescription, lastRefreshedAt } = __testing__;
+
+  // Reach into the same mocks we set up at the top of this file.
+  async function getMocks() {
+    const aiClientMod = await import('../ai-client');
+    const agentSessionMod = await import('../models/agentSession');
+    return {
+      complete: (aiClientMod as unknown as { aiClient: { complete: ReturnType<typeof vi.fn> } })
+        .aiClient.complete,
+      findAll: (
+        agentSessionMod as unknown as { AgentSession: { findAll: ReturnType<typeof vi.fn> } }
+      ).AgentSession.findAll,
+      findOne: (
+        agentSessionMod as unknown as { AgentSession: { findOne: ReturnType<typeof vi.fn> } }
+      ).AgentSession.findOne,
+      update: (agentSessionMod as unknown as { AgentSession: { update: ReturnType<typeof vi.fn> } })
+        .AgentSession.update,
+    };
+  }
+
+  it('returns silently when the group has no sessions', async () => {
+    const { findOne, complete, update } = await getMocks();
+    findOne.mockResolvedValueOnce(null);
+    complete.mockClear();
+    update.mockClear();
+
+    await refreshGroupDescription('sub-1', 'Empty Group', 'old description');
+
+    expect(complete).not.toHaveBeenCalled();
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('skips the LLM when there has been no activity since last refresh', async () => {
+    const { findOne, findAll, complete, update } = await getMocks();
+    lastRefreshedAt.clear();
+
+    const lastActive = new Date('2024-01-01T00:00:00Z');
+    findOne.mockResolvedValueOnce({ lastActiveAt: lastActive });
+    // Seed the in-memory marker as if we refreshed AFTER the newest activity.
+    lastRefreshedAt.set('sub-1::My App', new Date('2024-01-02T00:00:00Z'));
+
+    findAll.mockClear();
+    complete.mockClear();
+    update.mockClear();
+
+    await refreshGroupDescription('sub-1', 'My App', 'desc');
+
+    // findOne was called to get lastActiveAt; nothing else should happen.
+    expect(findAll).not.toHaveBeenCalled();
+    expect(complete).not.toHaveBeenCalled();
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('runs the LLM and updates when a session has been active since last refresh', async () => {
+    const { findOne, findAll, complete, update } = await getMocks();
+    lastRefreshedAt.clear();
+
+    const lastActive = new Date('2024-02-01T00:00:00Z');
+    findOne.mockResolvedValueOnce({ lastActiveAt: lastActive });
+    // No prior refresh marker → must run.
+    findAll.mockResolvedValueOnce([
+      {
+        historyJson: JSON.stringify([
+          { role: 'user', content: '<user_input>fix /Users/me/MyApp/index.ts</user_input>' },
+        ]),
+      },
+    ]);
+    complete.mockResolvedValueOnce({
+      content: JSON.stringify({
+        groupDescription:
+          'Project root: /Users/me/MyApp. Purpose: x. Primary language: TypeScript.',
+      }),
+    });
+    update.mockClear();
+
+    await refreshGroupDescription('sub-1', 'My App', 'old desc');
+
+    expect(complete).toHaveBeenCalledTimes(1);
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(lastRefreshedAt.get('sub-1::My App')).toBeInstanceOf(Date);
+  });
+});

--- a/api/src/__tests__/sessionGrouping.test.ts
+++ b/api/src/__tests__/sessionGrouping.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Unit tests for the pure helpers inside ../agent/sessionGrouping.
+ *
+ * These cover the regression where new sessions were being grouped under the
+ * PARENT project (e.g. the OmniKey-AI repo root) even when the user was
+ * clearly working in a sibling/child project. The root cause was two-fold:
+ *
+ * 1. extractUserInputs was returning the inner text of <user_input>...</user_input>
+ *    WITHOUT stripping the <project_context> block that the agent server
+ *    prepends to every turn of an already-grouped session. That meant the old
+ *    group's path was fed back into the classifier on every subsequent turn,
+ *    making the wrong grouping sticky forever.
+ *
+ * 2. extractProjectPath rolled scores up to every ancestor and broke ties by
+ *    picking the DEEPEST path, which let unrelated siblings like
+ *    /Users/<name>/src or even the bare /Users/<name> beat the real project
+ *    root.
+ *
+ * These tests pin both behaviours.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+// The module pulls in ai-client, sequelize models, and a logger at import
+// time. Stub all of them so the pure helpers can be exercised in isolation.
+vi.mock('../ai-client', () => ({
+  aiClient: { complete: vi.fn(), streamComplete: vi.fn() },
+  getDefaultModel: vi.fn(() => 'test-model'),
+}));
+
+vi.mock('../models/agentSession', () => ({
+  AgentSession: { findAll: vi.fn(), findOne: vi.fn(), update: vi.fn(), count: vi.fn() },
+}));
+
+vi.mock('../models/subscription', () => ({
+  Subscription: { findAll: vi.fn() },
+}));
+
+vi.mock('../config', () => ({
+  config: { aiProvider: 'openai' },
+}));
+
+vi.mock('../logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { __testing__ } from '../agent/sessionGrouping';
+
+const { extractUserInputs, extractProjectPath, stripInjectedWrappers, trimToProjectRoot } =
+  __testing__;
+
+// ---------------------------------------------------------------------------
+// stripInjectedWrappers
+// ---------------------------------------------------------------------------
+describe('stripInjectedWrappers', () => {
+  it('removes <project_context> blocks injected by the agent server', () => {
+    const input = `<project_context name="OmniKey AI">
+Project root: /Users/me/OmniKey-AI.
+</project_context>
+
+Hey, please look at /Users/me/NewProj/src/index.ts`;
+    const out = stripInjectedWrappers(input);
+    expect(out).not.toContain('project_context');
+    expect(out).not.toContain('/Users/me/OmniKey-AI');
+    expect(out).toContain('/Users/me/NewProj/src/index.ts');
+  });
+
+  it('removes <stored_instructions> blocks', () => {
+    const out = stripInjectedWrappers(
+      '<stored_instructions>do X</stored_instructions> the actual ask',
+    );
+    expect(out).toBe('the actual ask');
+  });
+
+  it('unwraps <user_input> tags without losing their content', () => {
+    const out = stripInjectedWrappers('<user_input>fix the bug</user_input>');
+    expect(out).toBe('fix the bug');
+  });
+
+  it('strips @omniagent mentions case-insensitively', () => {
+    expect(stripInjectedWrappers('@omniAgent help me')).toBe('help me');
+    expect(stripInjectedWrappers('@OMNIAGENT please')).toBe('please');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractUserInputs
+// ---------------------------------------------------------------------------
+describe('extractUserInputs', () => {
+  it('returns plain user inputs in order', () => {
+    const history = JSON.stringify([
+      { role: 'user', content: '<user_input>first message about /Users/me/AppA</user_input>' },
+      { role: 'assistant', content: 'ok' },
+      { role: 'user', content: '<user_input>second message about /Users/me/AppA</user_input>' },
+    ]);
+    expect(extractUserInputs(history)).toEqual([
+      'first message about /Users/me/AppA',
+      'second message about /Users/me/AppA',
+    ]);
+  });
+
+  it('skips terminal output and command error feedback messages', () => {
+    const history = JSON.stringify([
+      { role: 'user', content: '<user_input>fix /Users/me/AppA/index.ts</user_input>' },
+      { role: 'user', content: 'TERMINAL OUTPUT:\nsome long output' },
+      { role: 'user', content: 'COMMAND ERROR:\nstack trace' },
+    ]);
+    expect(extractUserInputs(history)).toEqual(['fix /Users/me/AppA/index.ts']);
+  });
+
+  it('strips <project_context> from inside <user_input> so old paths do not leak', () => {
+    // This is the regression: on turn 2 of a grouped session, the server
+    // prepends a <project_context> block (with the OLD group's path) inside
+    // <user_input>. extractUserInputs must not treat that injected text as
+    // user-typed content, otherwise the classifier keeps re-picking the old
+    // group.
+    const history = JSON.stringify([
+      {
+        role: 'user',
+        content: [
+          '<user_input>',
+          '<project_context name="OldParent">',
+          'Project root: /Users/me/OldParent.',
+          '</project_context>',
+          '',
+          'Now actually I am working on /Users/me/NewProj — please fix /Users/me/NewProj/main.ts',
+          '</user_input>',
+        ].join('\n'),
+      },
+    ]);
+
+    const inputs = extractUserInputs(history);
+    expect(inputs).toHaveLength(1);
+    expect(inputs[0]).not.toContain('project_context');
+    expect(inputs[0]).not.toContain('/Users/me/OldParent');
+    expect(inputs[0]).toContain('/Users/me/NewProj');
+  });
+
+  it('returns [] for malformed history JSON', () => {
+    expect(extractUserInputs('not json')).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// trimToProjectRoot
+// ---------------------------------------------------------------------------
+describe('trimToProjectRoot', () => {
+  it('strips a trailing file segment with an extension', () => {
+    expect(trimToProjectRoot('/Users/me/App/src/index.ts')).toBe('/Users/me/App');
+  });
+
+  it('walks up through non-root subdirs (src, lib, dist, tests, ...)', () => {
+    expect(trimToProjectRoot('/Users/me/App/src/components/Button.tsx')).toBe('/Users/me/App');
+    expect(trimToProjectRoot('/Users/me/App/dist/main.js')).toBe('/Users/me/App');
+    expect(trimToProjectRoot('/Users/me/App/__tests__/foo.test.ts')).toBe('/Users/me/App');
+  });
+
+  it('returns null for a bare home directory', () => {
+    expect(trimToProjectRoot('/Users/me')).toBeNull();
+    expect(trimToProjectRoot('/home/alice')).toBeNull();
+  });
+
+  it('skips Documents/Desktop/projects-style containers', () => {
+    expect(trimToProjectRoot('/Users/me/Documents')).toBeNull();
+    expect(trimToProjectRoot('/Users/me/Documents/projects/Real/src/x.ts')).toBe(
+      '/Users/me/Documents/projects/Real',
+    );
+  });
+
+  it('handles linux paths', () => {
+    expect(trimToProjectRoot('/home/alice/projects/Cool/src/main.go')).toBe(
+      '/home/alice/projects/Cool',
+    );
+  });
+
+  it('preserves paths outside home roots (e.g. /opt/myapp/src/x.ts)', () => {
+    expect(trimToProjectRoot('/opt/myapp/src/x.ts')).toBe('/opt/myapp');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractProjectPath — end-to-end on realistic input mixes
+// ---------------------------------------------------------------------------
+describe('extractProjectPath', () => {
+  it('returns null when no absolute paths are present', () => {
+    expect(extractProjectPath(['hello world', 'how are you'])).toBeNull();
+  });
+
+  it('returns null when the only path is the user home', () => {
+    expect(extractProjectPath(['home is /Users/gurindersingh'])).toBeNull();
+  });
+
+  it('picks the child project when the parent is mentioned once and the child many times', () => {
+    // This is the user-reported regression: an old <project_context> leaks
+    // ONE mention of the parent OmniKey-AI repo, but the user is clearly
+    // working in a different/child project. The child must win.
+    const got = extractProjectPath([
+      'old context /Users/gurindersingh/OmniKey-AI',
+      'fix /Users/gurindersingh/Subproject/a.ts',
+      'fix /Users/gurindersingh/Subproject/b.ts',
+      'fix /Users/gurindersingh/Subproject/c.ts',
+      'fix /Users/gurindersingh/Subproject/d.ts',
+    ]);
+    expect(got).toBe('/Users/gurindersingh/Subproject');
+  });
+
+  it('does not promote a bare home directory above an actual project', () => {
+    // Pre-fix, /Users/gurindersingh would score 4 (one ancestor vote per
+    // child path) and tie-break to depth 2, beating the real project.
+    const got = extractProjectPath([
+      'Please fix /Users/gurindersingh/MyOtherApp/src/index.ts',
+      'Also check /Users/gurindersingh/MyOtherApp/package.json',
+      'And /Users/gurindersingh/MyOtherApp/src/utils.ts',
+    ]);
+    expect(got).toBe('/Users/gurindersingh/MyOtherApp');
+  });
+
+  it('does not return a src/ or lib/ subdirectory', () => {
+    const got = extractProjectPath([
+      'fix /Users/x/MyApp/src/components/Button.tsx',
+      'and /Users/x/MyApp/src/components/Card.tsx',
+    ]);
+    expect(got).toBe('/Users/x/MyApp');
+  });
+
+  it('does not return an individual file path', () => {
+    const got = extractProjectPath(['edit /Users/me/Solo/index.ts']);
+    expect(got).toBe('/Users/me/Solo');
+  });
+
+  it('picks the deeper of two siblings when they tie on direct mentions', () => {
+    // When the same depth tie is between a true ancestor and its descendant
+    // (no other sibling), the descendant is the most-specific common
+    // reference and is more likely the project root the user means.
+    const got = extractProjectPath([
+      'Edit /Users/me/OmniKey-AI',
+      'Edit /Users/me/OmniKey-AI/cli',
+      'Edit /Users/me/OmniKey-AI/cli',
+    ]);
+    expect(got).toBe('/Users/me/OmniKey-AI/cli');
+  });
+
+  it('strips trailing sentence punctuation', () => {
+    const got = extractProjectPath([
+      'see /Users/me/MyApp/cli, please edit /Users/me/MyApp/cli/main.ts',
+    ]);
+    expect(got).toBe('/Users/me/MyApp/cli');
+  });
+
+  it('handles linux project paths', () => {
+    const got = extractProjectPath([
+      'fix /home/alice/projects/CoolApp/src/main.go',
+      'check /home/alice/projects/CoolApp/go.mod',
+    ]);
+    expect(got).toBe('/home/alice/projects/CoolApp');
+  });
+
+  it('regression: parent path leaked via <project_context> does not override child', () => {
+    // Realistic simulation of the bug the user reported. The agent server
+    // prepended <project_context> with the parent OmniKey-AI path, and the
+    // user typed a brand new request about a child project. With the old
+    // implementation the parent path would dominate via ancestor-rollup; the
+    // new implementation must pick the child.
+    const userTurnInsideHistory = [
+      '<project_context name="OmniKey AI">',
+      'Project root: /Users/me/OmniKey-AI. Purpose: parent. Primary language: TypeScript.',
+      '</project_context>',
+      '',
+      'Actually, please look at /Users/me/OmniKey-AI/cli and refactor /Users/me/OmniKey-AI/cli/src/main.ts',
+    ].join('\n');
+
+    const history = JSON.stringify([
+      { role: 'user', content: `<user_input>${userTurnInsideHistory}</user_input>` },
+    ]);
+    const inputs = extractUserInputs(history);
+    expect(inputs[0]).not.toContain('/Users/me/OmniKey-AI.');
+    const got = extractProjectPath(inputs);
+    expect(got).toBe('/Users/me/OmniKey-AI/cli');
+  });
+});

--- a/api/src/agent/sessionGrouping.ts
+++ b/api/src/agent/sessionGrouping.ts
@@ -52,7 +52,22 @@ function stripResponseWrappers(text: string): string {
 //      we have a deterministic fallback instead of a hallucination.
 //   3. Strip <stored_instructions>, the outer <user_input>, and @omniAgent
 //      the same as before.
+// Result of stripping injected wrappers. We keep the user-typed body and the
+// extracted context-root fallback lines as separate fields so the caller can
+// truncate the body alone — the fallback line is small and must always
+// survive truncation (otherwise we lose the only deterministic project-path
+// signal on long path-free turns).
+interface StrippedInput {
+  body: string;
+  contextPathsLine: string;
+}
+
 function stripInjectedWrappers(text: string): string {
+  const r = stripInjectedWrappersRich(text);
+  return r.contextPathsLine ? `${r.body}\n${r.contextPathsLine}`.trim() : r.body;
+}
+
+function stripInjectedWrappersRich(text: string): StrippedInput {
   const contextPaths: string[] = [];
   const withContextPathsExtracted = text.replace(
     /<project_context[^>]*>([\s\S]*?)<\/project_context>/gi,
@@ -62,16 +77,15 @@ function stripInjectedWrappers(text: string): string {
       return '';
     },
   );
-  const cleaned = withContextPathsExtracted
+  const body = withContextPathsExtracted
     .replace(/<stored_instructions>[\s\S]*?<\/stored_instructions>/gi, '')
     .replace(/<user_input>([\s\S]*?)<\/user_input>/gi, '$1')
     .replace(/@omniagent/gi, '')
     .trim();
-  if (!contextPaths.length) return cleaned;
-  // Re-append context paths as a single low-weight line. Each path appears
-  // once, prefixed so it does not look like the user typed prose.
-  const pathsLine = contextPaths.map((p) => `[context root] ${p}`).join('\n');
-  return cleaned ? `${cleaned}\n${pathsLine}` : pathsLine;
+  const contextPathsLine = contextPaths.length
+    ? contextPaths.map((p) => `[context root] ${p}`).join('\n')
+    : '';
+  return { body, contextPathsLine };
 }
 
 function extractUserInputs(historyJson: string): string[] {
@@ -94,11 +108,21 @@ function extractUserInputs(historyJson: string): string[] {
       // Extract the inner text from <user_input> wrapper if present, then
       // strip any server-injected blocks (project_context, stored_instructions)
       // so the classifier only sees what the user actually typed this turn.
+      // We truncate the user-typed BODY alone (cap at 400 chars) and then
+      // re-append the [context root] fallback line in full — the fallback is
+      // the only deterministic path signal we have on long path-free turns
+      // and must never be sliced off the end.
       const match = /<user_input>([\s\S]*?)<\/user_input>/i.exec(raw);
       const inner = match ? match[1] : raw;
-      const cleaned = stripInjectedWrappers(inner);
-      if (cleaned.length > 5) {
-        inputs.push(cleaned.slice(0, 400));
+      const { body, contextPathsLine } = stripInjectedWrappersRich(inner);
+      const truncatedBody = body.slice(0, 400);
+      const combined = contextPathsLine
+        ? truncatedBody
+          ? `${truncatedBody}\n${contextPathsLine}`
+          : contextPathsLine
+        : truncatedBody;
+      if (combined.length > 5) {
+        inputs.push(combined);
       }
     }
 
@@ -250,6 +274,27 @@ function isLocalLookingPath(path: string): boolean {
   return LOCAL_PATH_PREFIXES.some((re) => re.test(path));
 }
 
+// Centralised path matcher used by every absolute-path extractor in this
+// file. Returns a fresh /g RegExp on every call because /g RegExps carry
+// mutable lastIndex state between matchAll calls and would otherwise
+// silently desync across call sites.
+//
+// The matcher is intentionally UNBOUNDED on the number of trailing path
+// segments — a deep monorepo file like
+//   /Users/me/Documents/projects/org/monorepo/packages/api/src/index.ts
+// has 10 segments and we want to capture the full path so the downstream
+// trimToProjectRoot can walk it up to the real project root. A previous
+// hard cap of {1,6} truncated such paths into two halves and let the
+// shallower (".../packages") win the vote, classifying every deep
+// monorepo session under the wrong project.
+//
+// Path segments cannot contain whitespace, /, <>, quotes, or regex
+// metacharacters (?, ^, $, {, }, [, ], (, ), |, \\, *, +) that show up
+// in source code and config but are never valid in real filesystem paths.
+function buildAbsolutePathRegex(): RegExp {
+  return /(\/(?:[^\s/<>"'`?^${}\[\]()|\\*+]+\/)+[^\s/<>"'`?^${}\[\]()|\\*+]*)/g;
+}
+
 // First-segment patterns that mean a string starting with "/" is a URL or
 // domain that the agent server / a copy-paste accidentally turned into a
 // path-shaped token, NOT a real filesystem root. We reject these entirely
@@ -340,11 +385,7 @@ function extractProjectPath(texts: string[]): string | null {
     homeDir ? text.replace(/(^|[\s(\["'`])~\//g, (_m, pre: string) => `${pre}${homeDir}/`) : text;
   const combined = stripUrls(tildeExpand(texts.join(' ')));
 
-  // Match absolute paths (Unix) — capture up to 6 path segments.
-  // Path segments cannot contain whitespace, /, <>, quotes, or regex
-  // metacharacters that show up in source code and config but are never
-  // valid in real filesystem paths: ?, ^, $, {, }, [, ], (, ), |, \\, *, +.
-  const pathRe = /(\/(?:[^\s/<>"'`?^${}\[\]()|\\*+]+\/){1,6}[^\s/<>"'`?^${}\[\]()|\\*+]*)/g;
+  const pathRe = buildAbsolutePathRegex();
   const rawMatches = Array.from(combined.matchAll(pathRe), (m) => m[1])
     // Strip trailing sentence punctuation that the regex greedily included
     // (e.g. "see /Users/x/MyApp/cli, please edit ..." → /Users/x/MyApp/cli).
@@ -383,8 +424,10 @@ function extractProjectPath(texts: string[]): string | null {
     return b[0].split('/').length - a[0].split('/').length;
   });
 
-  const winner = entries[0][0];
-  return trimToProjectRoot(winner) ?? winner;
+  // winner came from `normalised`, which is itself a list of
+  // trimToProjectRoot outputs, so the path is already in its canonical
+  // trimmed form — no second pass needed here.
+  return entries[0][0];
 }
 
 // Return ALL normalised project roots referenced in the given texts together
@@ -397,10 +440,7 @@ function extractAllProjectRoots(texts: string[]): Array<{ root: string; votes: n
   const tildeExpand = (text: string): string =>
     homeDir ? text.replace(/(^|[\s(\["'`])~\//g, (_m, pre: string) => `${pre}${homeDir}/`) : text;
   const combined = stripUrls(tildeExpand(texts.join(' ')));
-  // Path segments cannot contain whitespace, /, <>, quotes, or regex
-  // metacharacters that show up in source code and config but are never
-  // valid in real filesystem paths: ?, ^, $, {, }, [, ], (, ), |, \\, *, +.
-  const pathRe = /(\/(?:[^\s/<>"'`?^${}\[\]()|\\*+]+\/){1,6}[^\s/<>"'`?^${}\[\]()|\\*+]*)/g;
+  const pathRe = buildAbsolutePathRegex();
   const rawMatches = Array.from(combined.matchAll(pathRe), (m) => m[1])
     .map((raw) => raw.replace(/[.,;:!?)\]]+$/, ''))
     .filter((raw) => raw.length > 1);
@@ -427,7 +467,7 @@ function extractKeySubdirectories(texts: string[], projectRoot: string, limit: n
   const tildeExpand = (text: string): string =>
     homeDir ? text.replace(/(^|[\s(\["'`])~\//g, (_m, pre: string) => `${pre}${homeDir}/`) : text;
   const combined = stripUrls(tildeExpand(texts.join(' ')));
-  const pathRe = /(\/(?:[^\s/<>"'`?^${}\[\]()|\\*+]+\/){1,8}[^\s/<>"'`?^${}\[\]()|\\*+]*)/g;
+  const pathRe = buildAbsolutePathRegex();
   const prefix = projectRoot.endsWith('/') ? projectRoot : projectRoot + '/';
   const votes = new Map<string, number>();
   for (const m of combined.matchAll(pathRe)) {

--- a/api/src/agent/sessionGrouping.ts
+++ b/api/src/agent/sessionGrouping.ts
@@ -251,7 +251,18 @@ function trimToProjectRoot(path: string): string | null {
 }
 
 function extractProjectPath(texts: string[]): string | null {
-  const combined = texts.join(' ');
+  // Resolve the current user's home directory once. We use it to expand
+  // "~/foo" tokens BEFORE running the absolute-path regex, so paths the
+  // user typed with a tilde prefix (e.g. "~/work/coderabbitai/grafana")
+  // are treated the same as "/Users/<name>/work/coderabbitai/grafana".
+  // Without this, the regex captured only the "/work/..." tail and
+  // accepted /work as a top-level root — which is how descriptions ended
+  // up storing "Project root: /work/coderabbitai/...".
+  const homeDir =
+    (typeof process !== 'undefined' && (process.env.HOME || process.env.USERPROFILE)) || '';
+  const tildeExpand = (text: string): string =>
+    homeDir ? text.replace(/(^|[\s(\["'`])~\//g, (_m, pre: string) => `${pre}${homeDir}/`) : text;
+  const combined = tildeExpand(texts.join(' '));
 
   // Match absolute paths (Unix) — capture up to 6 path segments.
   const pathRe = /(\/(?:[^\s/<>"'`]+\/){1,6}[^\s/<>"'`]*)/g;

--- a/api/src/agent/sessionGrouping.ts
+++ b/api/src/agent/sessionGrouping.ts
@@ -273,6 +273,49 @@ function buildDescription(projectPath: string | null, groupName: string): string
 }
 
 // ---------------------------------------------------------------------------
+// Helpers for matching existing groups by project path. Name-based matching
+// alone is unreliable: the LLM may pick "CLI" for two unrelated /cli dirs in
+// different repos, or rename the same project ("OmniKey AI" vs "OmniKey-AI").
+// Path matching is much stronger — when the deterministic project path
+// extracted from the current session equals an existing group's stored path,
+// we know with high confidence they are the same project.
+// ---------------------------------------------------------------------------
+
+/** Pull the project root path back out of a previously-stored group
+ *  description. Descriptions written by this module start with
+ *  "Project root: <absolute path>." so we just need to grab that span. */
+function extractStoredProjectPath(description: string | null | undefined): string | null {
+  if (!description) return null;
+  const match = /Project root:\s*(\/[^\s.,;:!?)<>"'`]+)/i.exec(description);
+  if (!match) return null;
+  const trimmed = trimToProjectRoot(match[1]);
+  return trimmed ?? match[1];
+}
+
+/** Pick the existing group whose stored project root EXACTLY equals the
+ *  current session's extracted project root. Equality is intentional — we do
+ *  NOT treat an ancestor match as a hit, because the original user complaint
+ *  was that a parent project was being chosen as the group for a child
+ *  project. /Users/me/OmniKey-AI/cli must not auto-merge into a group whose
+ *  stored path is /Users/me/OmniKey-AI. */
+function findGroupByExactPath(
+  currentPath: string | null,
+  existingGroups: Array<{ groupName: string; groupDescription: string | null }>,
+): { groupName: string; groupDescription: string } | null {
+  if (!currentPath) return null;
+  for (const g of existingGroups) {
+    const stored = extractStoredProjectPath(g.groupDescription);
+    if (stored && stored === currentPath) {
+      return {
+        groupName: g.groupName,
+        groupDescription: g.groupDescription ?? '',
+      };
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
 // LLM: classify group name AND generate a 3-4 sentence description for new
 // groups. For existing groups the stored description is always reused — the
 // LLM only writes a description when this is a genuinely new group. The
@@ -291,28 +334,79 @@ async function classifyGroup(
 ): Promise<GroupResult | null> {
   if (!userInputs.length) return null;
 
+  // Deterministically extract the project path from the current session. This
+  // is the single most reliable signal we have — far more reliable than the
+  // LLM's interpretation — so we use it both to short-circuit and to anchor
+  // the LLM's reasoning.
+  const currentPath = extractProjectPath(userInputs);
+
+  // 1) Path-first short-circuit. If any existing group already has the EXACT
+  //    same stored project root, that is the group. Skip the LLM entirely —
+  //    no name to invent, no chance of mis-matching to a parent repo.
+  if (currentPath) {
+    const exactMatch = findGroupByExactPath(currentPath, existingGroups);
+    if (exactMatch) {
+      logger.info('Session group matched by exact project path', {
+        groupName: exactMatch.groupName,
+        path: currentPath,
+      });
+      return {
+        groupName: exactMatch.groupName,
+        groupDescription: exactMatch.groupDescription,
+      };
+    }
+  }
+
+  // 2) Build the existing-groups list for the LLM, INCLUDING each group's
+  //    stored project root path when we can recover it. Without this the LLM
+  //    only sees group NAMES and has no way to disambiguate two projects that
+  //    happen to share a generic name (e.g. "CLI") or to avoid re-using the
+  //    parent repo's name when the user has moved on to a child project.
   const existingText = existingGroups.length
-    ? existingGroups.map((g) => `- "${g.groupName}"`).join('\n')
+    ? existingGroups
+        .map((g) => {
+          const storedPath = extractStoredProjectPath(g.groupDescription);
+          return storedPath
+            ? `- "${g.groupName}" (root: ${storedPath})`
+            : `- "${g.groupName}" (root: unknown)`;
+        })
+        .join('\n')
     : 'None.';
+
+  const currentPathLine = currentPath
+    ? `Project root detected in messages: ${currentPath}`
+    : 'No absolute project path was detected in the messages.';
 
   const prompt = `Analyze these chat messages and assign a project group.
 
 Messages:
 ${userInputs.map((m, i) => `${i + 1}. ${m}`).join('\n')}
 
-Existing groups:
+${currentPathLine}
+
+Existing groups (each shown with its stored project root):
 ${existingText}
 
-Rules for the group name:
-1. Look for file system paths, repository names, or project names in the messages.
-2. Identify the root project — if "/Users/john/projects/my-app/src/file.ts" appears, the group is "my-app".
-3. If an existing group clearly matches, return its EXACT name.
-4. Otherwise create a concise group name: 2-4 words, Title Case (e.g. "OmniKey AI", "Music Video Editor", "Client Website").
-5. If the session is purely general/conversational with no project signal, use "General".
+Rules for the group name (in priority order):
+1. If "Project root detected in messages" above is non-empty AND it is an
+   EXACT match for an existing group's stored root, return that existing
+   group's EXACT name verbatim. Do not modify the casing or punctuation.
+2. If "Project root detected in messages" is a STRICT ANCESTOR or
+   DESCENDANT of an existing group's stored root (e.g. detected is
+   /Users/me/Repo/cli and an existing group's root is /Users/me/Repo), they
+   are DIFFERENT projects — create a new group name for the detected path.
+   Do NOT re-use the ancestor or descendant group's name.
+3. If no path is detected but an existing group's NAME clearly matches the
+   subject of the messages, return that existing name.
+4. Otherwise create a concise NEW group name: 2-4 words, Title Case, derived
+   from the deepest meaningful path segment (e.g. /Users/john/projects/my-app
+   → "My App") or from the topic when no path is present.
+5. If the session is purely general/conversational with no project signal,
+   use "General".
 
 Rules for the description (CRITICAL):
 The description is appended to user input as <project_context> whenever the user picks this project, so it must be short, factual, and load-bearing. Write a SINGLE paragraph of 3-4 sentences (max 4 sentences, no markdown, no bullet points, no newlines) that answers these three questions in order:
-   1. Where is the project root located? Quote the exact absolute path verbatim when one is present in the messages (e.g. "Project root: /Users/john/projects/my-app."). If no path is present, say so explicitly.
+   1. Where is the project root located? Use the EXACT "Project root detected in messages" path above when it is non-empty — do not invent, abbreviate, or guess a different path. If it is empty, say "Project root: not specified."
    2. What is the purpose of this project? One sentence summarising what the project / group is for, inferred from the messages.
    3. If it is a coding project, what is the primary programming language? Name the language (e.g. TypeScript, Python, Go, Rust) when it can be inferred from file extensions, framework names, package files, or explicit mentions. If it is not a coding project, say "Not a coding project." If the language cannot be inferred, say "Primary language not identified from the available context."
 Keep the whole description under ~500 characters. Do NOT add extra commentary, tech-stack lists, workflow notes, or session summaries beyond what the three questions require.
@@ -340,7 +434,7 @@ Respond with ONLY valid JSON, no markdown:
     const response = z
       .object({ groupName: z.string(), groupDescription: z.string() })
       .parse(parsed);
-    const groupName = response.groupName.trim().slice(0, 100);
+    let groupName = response.groupName.trim().slice(0, 100);
     if (!groupName) return null;
 
     // When we fall through from the existingMatch branch to regenerate a stale
@@ -348,13 +442,41 @@ Respond with ONLY valid JSON, no markdown:
     // fragment groups by re-casing the name.
     let canonicalName: string | null = null;
 
-    // If this matches an existing group, reuse the stored description ONLY when it
-    // already follows the new shape (must mention "Project root" and "Primary
-    // language"). Otherwise fall through and let the LLM-generated description
-    // replace it, so old verbose descriptions are upgraded in place.
-    const existingMatch = existingGroups.find(
+    // Locate the LLM-chosen existing group, if any. We then VALIDATE the
+    // match against project paths — the LLM's name-based pick may be wrong:
+    // it might re-use a parent project's name even when the user is in a
+    // child project, or vice versa.
+    let existingMatch = existingGroups.find(
       (g) => g.groupName.toLowerCase() === groupName.toLowerCase(),
     );
+
+    if (existingMatch && currentPath) {
+      const storedPath = extractStoredProjectPath(existingMatch.groupDescription);
+      if (storedPath && storedPath !== currentPath) {
+        // The LLM picked an existing name but the stored path for that group
+        // does not match the path the user is actually in. Treat this as a
+        // NEW group and drop the existing-match so we don't merge unrelated
+        // projects (or, worse, the parent of the current project).
+        logger.info('Rejecting LLM existing-group match: project paths differ', {
+          groupName,
+          storedPath,
+          currentPath,
+        });
+        existingMatch = undefined;
+        // Derive a sensible new name from the current path instead of
+        // re-using the LLM's name (which is already taken by the other
+        // project). Title-case the last segment.
+        const segs = currentPath.split('/').filter(Boolean);
+        const last = segs[segs.length - 1] ?? groupName;
+        const derived = last
+          .replace(/[_-]+/g, ' ')
+          .replace(/\b\w/g, (c) => c.toUpperCase())
+          .trim()
+          .slice(0, 100);
+        if (derived) groupName = derived;
+      }
+    }
+
     if (existingMatch) {
       const stored = existingMatch.groupDescription ?? '';
       const hasNewShape = /project root/i.test(stored) && /primary language/i.test(stored);
@@ -366,20 +488,56 @@ Respond with ONLY valid JSON, no markdown:
       canonicalName = existingMatch.groupName;
     }
 
+    // Final safety net: if currentPath EXACTLY matches some other existing
+    // group's stored path (different name than the LLM picked), prefer that
+    // group. The LLM is allowed to invent a name, but path equality is
+    // ground truth.
+    if (currentPath) {
+      const pathMatch = findGroupByExactPath(currentPath, existingGroups);
+      if (pathMatch && pathMatch.groupName.toLowerCase() !== groupName.toLowerCase()) {
+        logger.info('Overriding LLM group choice with exact-path match', {
+          llmGroup: groupName,
+          matchedGroup: pathMatch.groupName,
+          path: currentPath,
+        });
+        return {
+          groupName: pathMatch.groupName,
+          groupDescription: pathMatch.groupDescription,
+        };
+      }
+    }
+
     // New group: prefer the LLM description but fall back to the deterministic builder.
     // Description is a single 3-4 sentence paragraph (no newlines, capped at 800 chars
     // to leave headroom over the ~500 char target while still bounding storage).
     const rawDesc = response.groupDescription.trim();
-    const projectPath = extractProjectPath(userInputs);
-    let groupDescription = (rawDesc || buildDescription(projectPath, groupName))
+    let groupDescription = (rawDesc || buildDescription(currentPath, groupName))
       .replace(/\s*\n+\s*/g, ' ')
       .replace(/\s{2,}/g, ' ')
       .trim();
 
-    // Safety net: if the LLM ignored the rule and a path exists in the messages
-    // but is missing from the description, append it so the contract holds.
-    if (projectPath && !groupDescription.includes(projectPath)) {
-      groupDescription = `Project root: ${projectPath}. ${groupDescription}`.trim();
+    // Safety net 1: if the LLM hallucinated a different absolute path in its
+    // "Project root:" sentence, replace it with the deterministically
+    // extracted currentPath. This is the description the agent server will
+    // inject as <project_context> on every future turn, so a wrong path here
+    // poisons the session forever.
+    if (currentPath) {
+      groupDescription = groupDescription.replace(
+        /Project root:\s*(\/[^\s.,;:!?)<>"'`]+)/i,
+        (_m, llmPath: string) => {
+          if (llmPath === currentPath) return `Project root: ${currentPath}`;
+          logger.info('Replacing hallucinated description path with extracted path', {
+            llmPath,
+            currentPath,
+          });
+          return `Project root: ${currentPath}`;
+        },
+      );
+      // Safety net 2: if the description never mentioned a path at all,
+      // prepend the extracted one so the contract holds.
+      if (!groupDescription.includes(currentPath)) {
+        groupDescription = `Project root: ${currentPath}. ${groupDescription}`.trim();
+      }
     }
 
     groupDescription = groupDescription.slice(0, 800);
@@ -502,8 +660,26 @@ Respond with ONLY valid JSON: {"groupDescription":"..."}`;
       .replace(/\s{2,}/g, ' ')
       .trim();
 
-    if (projectPath && !description.includes(projectPath)) {
-      description = `Project root: ${projectPath}. ${description}`.trim();
+    // If the LLM wrote a "Project root: <path>" sentence with a path that
+    // doesn't match the path we deterministically extracted, override it.
+    // The description is injected verbatim into every future user turn, so
+    // a wrong path here is what makes a mis-grouped session sticky.
+    if (projectPath) {
+      description = description.replace(
+        /Project root:\s*(\/[^\s.,;:!?)<>"'`]+)/i,
+        (_m, llmPath: string) => {
+          if (llmPath === projectPath) return `Project root: ${projectPath}`;
+          logger.info('enrichGroupDescription: replacing hallucinated path', {
+            groupName,
+            llmPath,
+            projectPath,
+          });
+          return `Project root: ${projectPath}`;
+        },
+      );
+      if (!description.includes(projectPath)) {
+        description = `Project root: ${projectPath}. ${description}`.trim();
+      }
     }
 
     return description.slice(0, 800);
@@ -738,4 +914,7 @@ export const __testing__ = {
   extractProjectPath,
   stripInjectedWrappers,
   trimToProjectRoot,
+  extractStoredProjectPath,
+  findGroupByExactPath,
+  classifyGroup,
 };

--- a/api/src/agent/sessionGrouping.ts
+++ b/api/src/agent/sessionGrouping.ts
@@ -265,7 +265,10 @@ function extractProjectPath(texts: string[]): string | null {
   const combined = tildeExpand(texts.join(' '));
 
   // Match absolute paths (Unix) — capture up to 6 path segments.
-  const pathRe = /(\/(?:[^\s/<>"'`]+\/){1,6}[^\s/<>"'`]*)/g;
+  // Path segments cannot contain whitespace, /, <>, quotes, or regex
+  // metacharacters that show up in source code and config but are never
+  // valid in real filesystem paths: ?, ^, $, {, }, [, ], (, ), |, \\, *, +.
+  const pathRe = /(\/(?:[^\s/<>"'`?^${}\[\]()|\\*+]+\/){1,6}[^\s/<>"'`?^${}\[\]()|\\*+]*)/g;
   const rawMatches = Array.from(combined.matchAll(pathRe), (m) => m[1])
     // Strip trailing sentence punctuation that the regex greedily included
     // (e.g. "see /Users/x/MyApp/cli, please edit ..." → /Users/x/MyApp/cli).
@@ -306,6 +309,99 @@ function extractProjectPath(texts: string[]): string | null {
 
   const winner = entries[0][0];
   return trimToProjectRoot(winner) ?? winner;
+}
+
+// Return ALL normalised project roots referenced in the given texts together
+// with their direct-vote count, ordered by score then by path. Used by the
+// cron to detect groups that have drifted across multiple unrelated projects
+// and need to be split.
+function extractAllProjectRoots(texts: string[]): Array<{ root: string; votes: number }> {
+  const homeDir =
+    (typeof process !== 'undefined' && (process.env.HOME || process.env.USERPROFILE)) || '';
+  const tildeExpand = (text: string): string =>
+    homeDir ? text.replace(/(^|[\s(\["'`])~\//g, (_m, pre: string) => `${pre}${homeDir}/`) : text;
+  const combined = tildeExpand(texts.join(' '));
+  // Path segments cannot contain whitespace, /, <>, quotes, or regex
+  // metacharacters that show up in source code and config but are never
+  // valid in real filesystem paths: ?, ^, $, {, }, [, ], (, ), |, \\, *, +.
+  const pathRe = /(\/(?:[^\s/<>"'`?^${}\[\]()|\\*+]+\/){1,6}[^\s/<>"'`?^${}\[\]()|\\*+]*)/g;
+  const rawMatches = Array.from(combined.matchAll(pathRe), (m) => m[1])
+    .map((raw) => raw.replace(/[.,;:!?)\]]+$/, ''))
+    .filter((raw) => raw.length > 1);
+  const votes = new Map<string, number>();
+  for (const raw of rawMatches) {
+    const trimmed = trimToProjectRoot(raw);
+    if (!trimmed) continue;
+    votes.set(trimmed, (votes.get(trimmed) ?? 0) + 1);
+  }
+  return Array.from(votes.entries())
+    .map(([root, n]) => ({ root, votes: n }))
+    .sort((a, b) => (b.votes !== a.votes ? b.votes - a.votes : a.root.length - b.root.length));
+}
+
+// Return the most-referenced sub-directories UNDER a given project root,
+// ordered by reference count then by depth, capped at `limit`. The trailing
+// file segment (if any) is stripped, but unlike trimToProjectRoot we keep
+// non-root subdirs (src, lib, dist, ...) because those are exactly the
+// "key directories worked on" the description should mention.
+function extractKeySubdirectories(texts: string[], projectRoot: string, limit: number): string[] {
+  if (!projectRoot) return [];
+  const homeDir =
+    (typeof process !== 'undefined' && (process.env.HOME || process.env.USERPROFILE)) || '';
+  const tildeExpand = (text: string): string =>
+    homeDir ? text.replace(/(^|[\s(\["'`])~\//g, (_m, pre: string) => `${pre}${homeDir}/`) : text;
+  const combined = tildeExpand(texts.join(' '));
+  const pathRe = /(\/(?:[^\s/<>"'`?^${}\[\]()|\\*+]+\/){1,8}[^\s/<>"'`?^${}\[\]()|\\*+]*)/g;
+  const prefix = projectRoot.endsWith('/') ? projectRoot : projectRoot + '/';
+  const votes = new Map<string, number>();
+  for (const m of combined.matchAll(pathRe)) {
+    const raw = m[1].replace(/[.,;:!?)\]]+$/, '');
+    if (!raw.startsWith(prefix)) continue;
+    const parts = raw.split('/').filter(Boolean);
+    // Strip trailing file segment, if any.
+    if (parts.length && looksLikeFile(parts[parts.length - 1])) {
+      parts.pop();
+    }
+    // Need at least one segment beyond the project root to be a subdir.
+    const rootDepth = projectRoot.split('/').filter(Boolean).length;
+    if (parts.length <= rootDepth) continue;
+    // Walk every ancestor depth strictly deeper than the root, capping at
+    // root + 3 segments so we don't promote one-off deeply-nested files.
+    const maxDepth = Math.min(parts.length, rootDepth + 3);
+    for (let depth = rootDepth + 1; depth <= maxDepth; depth++) {
+      const sub = '/' + parts.slice(0, depth).join('/');
+      votes.set(sub, (votes.get(sub) ?? 0) + 1);
+    }
+  }
+  return Array.from(votes.entries())
+    .filter(([, n]) => n >= 1)
+    .sort((a, b) => (b[1] !== a[1] ? b[1] - a[1] : a[0].split('/').length - b[0].split('/').length))
+    .slice(0, limit)
+    .map(([sub]) => sub);
+}
+
+// Truncate to at most `maxLen` characters but never mid-word, preferring to
+// end on a sentence boundary (.!?). Falls back to the last whitespace.
+function truncateOnSentenceBoundary(text: string, maxLen: number): string {
+  if (text.length <= maxLen) return text;
+  const slice = text.slice(0, maxLen);
+  // Prefer the last sentence terminator followed by a space (or end).
+  const sentenceMatch = /[.!?](?=\s|$)(?!.*[.!?](?=\s|$))/s.exec(slice);
+  if (sentenceMatch && sentenceMatch.index > maxLen * 0.5) {
+    return slice.slice(0, sentenceMatch.index + 1).trimEnd();
+  }
+  // Otherwise back off to the last whitespace so we don't cut a word.
+  const lastSpace = slice.lastIndexOf(' ');
+  if (lastSpace > maxLen * 0.5) {
+    return (
+      slice
+        .slice(0, lastSpace)
+        .trimEnd()
+        .replace(/[,;:]$/, '') + '.'
+    );
+  }
+  // Last resort: hard truncate, but always end on a period.
+  return slice.trimEnd().replace(/[,;:.!?]+$/, '') + '.';
 }
 
 // ---------------------------------------------------------------------------
@@ -606,7 +702,8 @@ Respond with ONLY valid JSON, no markdown:
       }
     }
 
-    groupDescription = groupDescription.slice(0, 800);
+    // Cap on a sentence boundary so we never store truncated mid-token text.
+    groupDescription = truncateOnSentenceBoundary(groupDescription, 1000);
 
     return {
       // Preserve the canonical existing group name when we fell through from
@@ -663,10 +760,16 @@ async function enrichGroupDescription(
   allInputs: string[],
   existingDescription: string | null,
   isUpdateMode: boolean,
+  forcedProjectPath?: string | null,
 ): Promise<string | null> {
   if (!allInputs.length) return null;
 
-  const projectPath = extractProjectPath(allInputs);
+  // Use the caller-provided project root when given (the cron passes the
+  // collapsed dominant root for the group, which is the correct project root
+  // even when individual sessions only reference subdirectories). Fall back
+  // to running our own extraction otherwise — that's the path taken from
+  // updateSessionGroup for a single session.
+  const projectPath = forcedProjectPath ?? extractProjectPath(allInputs);
   const messagesText = allInputs.map((m, i) => `${i + 1}. ${m}`).join('\n');
 
   // Hand the LLM the deterministically extracted root explicitly. Before
@@ -681,6 +784,15 @@ async function enrichGroupDescription(
     ? `Deterministically extracted project root for this group: ${projectPath}\n(Use this EXACT path in the "Project root:" sentence. Do not abbreviate, do not paraphrase, do not substitute a URL for it.)`
     : 'No absolute project root could be deterministically extracted from the messages. Say "Project root: not specified." in the description.';
 
+  // Surface the key sub-directories the user has been working on inside this
+  // project so the description can mention them. The LLM is instructed to
+  // weave them in as a single sentence — they are not the project root, just
+  // landmarks within it (e.g. /Users/me/Repo/api/src/agent, /Users/me/Repo/cli).
+  const keySubdirs = projectPath ? extractKeySubdirectories(allInputs, projectPath, 4) : [];
+  const keySubdirsLine = keySubdirs.length
+    ? `Key sub-directories worked on inside this project (most-referenced first):\n${keySubdirs.map((s) => `  - ${s}`).join('\n')}`
+    : 'No notable sub-directories were identified inside the project root.';
+
   const prompt =
     isUpdateMode && existingDescription
       ? `Update the project group description for "${groupName}" based on new session data.
@@ -690,30 +802,42 @@ Current description:
 
 ${projectPathLine}
 
+${keySubdirsLine}
+
 Recent user messages from sessions in this group:
 ${messagesText}
 
-Update the description to incorporate any new findings. Keep the same 3-4 sentence structure answering in order:
+A GROUP CORRESPONDS TO EXACTLY ONE PROJECT. The description must describe ONLY the project at the project root above. Do not mention any other project root. Do not merge information about multiple unrelated projects into one description — the cron will split them into separate groups on its own.
+
+Update the description to incorporate any new findings. Keep a 4-5 sentence single paragraph answering in order:
 1. Where is the project root? Use the deterministically extracted path above when one was provided. Never use a URL (github.com/..., linear.app/..., console.cloud.google.com/...) as the project root.
 2. What is the purpose of this project?
-3. What is the primary programming language?
+3. What are the main sub-directories worked on inside the project? Mention the most useful 2-3 from the key sub-directories list above (use their exact absolute paths). Skip this sentence if no sub-directories were identified.
+4. What is the primary programming language?
+5. (Optional, only if clearly inferable) What is the current focus of recent work, in one short clause.
 
-Rules: single paragraph, under ~500 characters, no markdown, no bullet points, no newlines. Preserve correct existing information. Only change what the messages provide new or better details on.
+Rules: single paragraph, no markdown, no bullet points, no newlines, end on a complete sentence. Keep under ~650 characters total. Preserve correct existing information. Only change what the messages provide new or better details on.
 
 Respond with ONLY valid JSON: {"groupDescription":"..."}`
       : `Generate a description for the project group "${groupName}" based on these session messages.
 
 ${projectPathLine}
 
+${keySubdirsLine}
+
 Messages:
 ${messagesText}
 
-Write a SINGLE paragraph of 3-4 sentences (no markdown, no bullet points, no newlines) answering in order:
+A GROUP CORRESPONDS TO EXACTLY ONE PROJECT. Describe ONLY the project at the project root above. Do not mention any other project root and do not merge multiple unrelated projects into one description.
+
+Write a SINGLE paragraph of 4-5 sentences (no markdown, no bullet points, no newlines, end on a complete sentence) answering in order:
 1. Where is the project root? Use the deterministically extracted path above when one was provided; never use a URL.
 2. What is the purpose of this project?
-3. What is the primary programming language? (Name it when inferable; "Primary language not identified." if not.)
+3. What are the main sub-directories worked on inside the project? Mention the most useful 2-3 from the key sub-directories list above (use their exact absolute paths). Skip if none.
+4. What is the primary programming language? (Name it when inferable; "Primary language not identified." if not.)
+5. (Optional) Current focus of recent work, in one short clause.
 
-Keep the whole description under ~500 characters.
+Keep the whole description under ~650 characters.
 
 Respond with ONLY valid JSON: {"groupDescription":"..."}`;
 
@@ -764,7 +888,11 @@ Respond with ONLY valid JSON: {"groupDescription":"..."}`;
       }
     }
 
-    return description.slice(0, 800);
+    // Cap on a sentence boundary so we never store "...Primary language: GPT-5"
+    // (cut mid-token by the old hard slice). Hard limit raised from 800 to 1000
+    // to accommodate the new sentence about key sub-directories, with the
+    // truncator picking the last complete sentence inside that budget.
+    return truncateOnSentenceBoundary(description, 1000);
   } catch (err) {
     logger.warn('Group description enrichment failed', { groupName, error: err });
     return null;
@@ -892,30 +1020,129 @@ async function refreshGroupDescription(
       where: { subscriptionId, groupName },
       order: [['last_active_at', 'DESC']],
       limit: 15,
-      attributes: ['historyJson'],
+      attributes: ['id', 'historyJson'],
     });
 
+    // Per-session inputs + each session's dominant project root. Used both
+    // to detect groups that have drifted across multiple unrelated projects
+    // (which we then split — one project per group is a hard invariant) and
+    // to build the LLM prompt from ONLY the sessions that actually belong to
+    // the dominant root.
+    type Resolved = { id: string; inputs: string[]; root: string | null };
+    const resolved: Resolved[] = sessions.map((s) => {
+      const inputs = extractUserInputs(s.historyJson);
+      return { id: s.id, inputs, root: extractProjectPath(inputs) };
+    });
+
+    // Count direct votes per root (sessions with no detectable root don't
+    // contribute to the split decision, they ride along with whatever wins).
+    const rawRootCounts = new Map<string, number>();
+    for (const r of resolved) {
+      if (r.root) rawRootCounts.set(r.root, (rawRootCounts.get(r.root) ?? 0) + 1);
+    }
+
+    // Collapse roots that are in an ancestor/descendant relationship into the
+    // SHALLOWEST one — they are the same project, just referenced at
+    // different depths (e.g. one session edits files in /Users/me/Repo, the
+    // next edits files in /Users/me/Repo/api). Without this collapse the
+    // split logic would treat /Users/me/Repo and /Users/me/Repo/api as two
+    // separate projects and demote half the group on every tick.
+    const isAncestorOrEqual = (a: string, b: string): boolean =>
+      a === b || b.startsWith(a.endsWith('/') ? a : a + '/');
+    const rawRoots = Array.from(rawRootCounts.keys());
+    const canonicalOf = new Map<string, string>();
+    for (const root of rawRoots) {
+      let canonical = root;
+      for (const other of rawRoots) {
+        if (other === root) continue;
+        if (isAncestorOrEqual(other, canonical)) canonical = other;
+      }
+      canonicalOf.set(root, canonical);
+    }
+    const rootCounts = new Map<string, number>();
+    for (const [root, votes] of rawRootCounts.entries()) {
+      const canon = canonicalOf.get(root) ?? root;
+      rootCounts.set(canon, (rootCounts.get(canon) ?? 0) + votes);
+    }
+
+    // Dominant root: the canonical project most-referenced across sessions.
+    // Ties are broken by shorter path (more likely the actual project root
+    // when two truly disjoint trees somehow tie).
+    const ranked = Array.from(rootCounts.entries()).sort((a, b) =>
+      b[1] !== a[1] ? b[1] - a[1] : a[0].length - b[0].length,
+    );
+    const dominantRoot = ranked.length ? ranked[0][0] : null;
+
+    // SPLIT: any session whose canonical root is non-null and DIFFERENT
+    // from the dominant root does not belong in this group. We clear its
+    // groupName/groupDescription so the next cron tick re-classifies it
+    // into its own (likely new) group. We deliberately do NOT move it to a
+    // specific named group here — classifyGroup handles naming, including
+    // the path-match short-circuit that will merge it into an existing
+    // sibling group if one already represents the same root.
+    if (dominantRoot) {
+      const stragglerIds = resolved
+        .filter((r) => {
+          if (!r.root) return false;
+          const canon = canonicalOf.get(r.root) ?? r.root;
+          return canon !== dominantRoot;
+        })
+        .map((r) => r.id);
+      if (stragglerIds.length > 0) {
+        logger.info(
+          'Splitting polluted group: demoting sessions whose root differs from the dominant root',
+          {
+            subscriptionId,
+            groupName,
+            dominantRoot,
+            stragglerCount: stragglerIds.length,
+            otherRoots: Array.from(rootCounts.entries())
+              .filter(([r]) => r !== dominantRoot)
+              .map(([r, n]) => `${r} (${n})`),
+          },
+        );
+        await AgentSession.update(
+          { groupName: null, groupDescription: null },
+          { where: { id: { [Op.in]: stragglerIds } } },
+        );
+      }
+    }
+
+    // Collect inputs ONLY from sessions that belong to the dominant root
+    // (or, if we couldn't detect a root at all, every session in the group).
+    // Without this filter the LLM would still see prose from the demoted
+    // sessions and weave their paths/topics into the description.
     const allInputs: string[] = [];
-    for (const s of sessions) {
-      for (const inp of extractUserInputs(s.historyJson)) {
+    for (const r of resolved) {
+      if (dominantRoot && r.root) {
+        const canon = canonicalOf.get(r.root) ?? r.root;
+        if (canon !== dominantRoot) continue;
+      }
+      for (const inp of r.inputs) {
         allInputs.push(inp);
         if (allInputs.length >= 10) break;
       }
       if (allInputs.length >= 10) break;
     }
 
-    if (!allInputs.length) return;
+    if (!allInputs.length) {
+      // Mark the refresh as done so we don't spin on this group every tick.
+      lastRefreshedAt.set(refreshKey(subscriptionId, groupName), new Date());
+      return;
+    }
 
     const newDescription = await enrichGroupDescription(
       groupName,
       allInputs,
       existingDescription,
       true,
+      dominantRoot,
     );
 
     if (!newDescription) return;
 
-    // Sync the updated description to every session in this group.
+    // Sync the updated description to every session that REMAINS in this
+    // group (i.e. excluding the just-demoted stragglers).
     await AgentSession.update(
       { groupDescription: newDescription },
       { where: { subscriptionId, groupName } },
@@ -923,7 +1150,7 @@ async function refreshGroupDescription(
 
     lastRefreshedAt.set(refreshKey(subscriptionId, groupName), new Date());
 
-    logger.info('Group description refreshed', { subscriptionId, groupName });
+    logger.info('Group description refreshed', { subscriptionId, groupName, dominantRoot });
   } catch (err) {
     logger.error('Failed to refresh group description', { subscriptionId, groupName, error: err });
   }
@@ -1088,6 +1315,9 @@ export function startGroupingCronJob(): void {
 export const __testing__ = {
   extractUserInputs,
   extractProjectPath,
+  extractAllProjectRoots,
+  extractKeySubdirectories,
+  truncateOnSentenceBoundary,
   stripInjectedWrappers,
   trimToProjectRoot,
   extractStoredProjectPath,

--- a/api/src/agent/sessionGrouping.ts
+++ b/api/src/agent/sessionGrouping.ts
@@ -184,6 +184,72 @@ const HOME_CONTAINER_SEGMENTS = new Set([
   'github',
 ]);
 
+// Strip every URL-shaped token from the input BEFORE the path regex runs.
+// We accept that real filesystem paths NEVER contain a scheme prefix
+// (http://, https://, ftp://, ssh://, git+, file://, mailto:, etc.) and we
+// also strip bare git remotes (git@host:owner/repo.git), scheme-relative
+// URLs (//host.tld/path) and unprefixed host-with-TLD references
+// (github.com/foo/bar). After this pass the input only contains real
+// filesystem candidate paths and prose, so the downstream path regex never
+// has to wonder "is this a URL?". We replace with a single space rather
+// than empty string so adjacent path tokens stay separated.
+const URL_LIKE_REGEXES: readonly RegExp[] = [
+  // Full URLs with scheme: http(s)://, ftp(s)://, ssh://, git://, git+...://,
+  // file://, ws(s)://, etc. Anything up to the next whitespace / quote / >.
+  /\b(?:https?|ftps?|sftp|ssh|git|git\+ssh|git\+https?|file|ws|wss|chrome|chrome-extension|vscode|data)(?::\/\/|:)[^\s<>"'`]+/gi,
+  // Scheme-relative URLs (//host.tld/path).
+  /(?<![A-Za-z0-9_])\/\/[a-z0-9-]+(?:\.[a-z0-9-]+)+(?::\d+)?(?:\/[^\s<>"'`]*)?/gi,
+  // git remotes: git@host:owner/repo(.git).
+  /\bgit@[a-z0-9.-]+:[^\s<>"'`]+/gi,
+  // mailto:user@host.
+  /\bmailto:[^\s<>"'`]+/gi,
+  // Bare URL with TLD but no scheme: github.com/foo, example.com:8080/path,
+  // localhost:port/path. Requires the host to contain at least one dot OR
+  // to be a port-bearing localhost — without that constraint we would eat
+  // every "foo.bar" token in regular prose.
+  /\b(?:[a-z0-9-]+\.[a-z0-9-]+(?:\.[a-z0-9-]+)*(?::\d+)?|localhost:\d+)\/[^\s<>"'`]*/gi,
+];
+
+function stripUrls(text: string): string {
+  let out = text;
+  for (const re of URL_LIKE_REGEXES) out = out.replace(re, ' ');
+  return out;
+}
+
+// Positive filter: only accept paths whose leading segments look like
+// real local-computer roots. This is intentionally an allow-list — the
+// classifier's job is to identify the user's PROJECT, and real projects
+// live somewhere predictable on disk. Anything that doesn't start with
+// one of these prefixes is almost certainly a URL fragment, a route, or
+// some other path-shaped noise; we drop it rather than guess.
+//
+// Macs and most Linux installs: /Users/<x>/..., /home/<x>/..., /opt/...,
+// /usr/local/..., /var/..., /tmp/..., /private/Users/<x>/...,
+// /Volumes/<vol>/..., /mnt/<vol>/..., /srv/..., /etc/..., /root/...
+// Tilde paths (~/foo) are pre-expanded to /Users/<x>/foo before this
+// filter runs, so they go through the /Users branch.
+const LOCAL_PATH_PREFIXES: ReadonlyArray<RegExp> = [
+  /^\/Users\/[^/]+(?:\/|$)/,
+  /^\/home\/[^/]+(?:\/|$)/,
+  /^\/private\/var\/folders\//,
+  /^\/private\/tmp(?:\/|$)/,
+  /^\/private\/Users\/[^/]+(?:\/|$)/,
+  /^\/Volumes\/[^/]+(?:\/|$)/,
+  /^\/mnt\/[^/]+(?:\/|$)/,
+  /^\/opt\/[^/]+(?:\/|$)/,
+  /^\/usr\/local(?:\/|$)/,
+  /^\/usr\/share(?:\/|$)/,
+  /^\/srv\/[^/]+(?:\/|$)/,
+  /^\/var\/[^/]+(?:\/|$)/,
+  /^\/tmp\/[^/]+(?:\/|$)/,
+  /^\/etc\/[^/]+(?:\/|$)/,
+  /^\/root(?:\/|$)/,
+];
+
+function isLocalLookingPath(path: string): boolean {
+  return LOCAL_PATH_PREFIXES.some((re) => re.test(path));
+}
+
 // First-segment patterns that mean a string starting with "/" is a URL or
 // domain that the agent server / a copy-paste accidentally turned into a
 // path-shaped token, NOT a real filesystem root. We reject these entirely
@@ -220,6 +286,16 @@ function trimToProjectRoot(path: string): string | null {
   // is exactly how stale descriptions ended up storing things like
   // "Project root: /github.com/coderabbitai/grafana/pull/220".
   if (parts.length > 0 && firstSegmentLooksLikeDomain(parts[0])) {
+    return null;
+  }
+  // Allow-list: only paths rooted under a known local-computer prefix
+  // (/Users/<x>/, /home/<x>/, /opt/, /Volumes/<vol>/, ...) are treated as
+  // real project roots. Anything else — top-level pseudo-roots like
+  // /work/coderabbitai/mono or /db-api-server/src/routers, route paths
+  // bleeding out of URLs the stripper missed, the macOS volume root — is
+  // dropped rather than guessed at. This is the "only consider paths
+  // that look like paths from a local computer" rule.
+  if (!isLocalLookingPath('/' + parts.join('/'))) {
     return null;
   }
   // Strip a trailing file segment, if any.
@@ -262,7 +338,7 @@ function extractProjectPath(texts: string[]): string | null {
     (typeof process !== 'undefined' && (process.env.HOME || process.env.USERPROFILE)) || '';
   const tildeExpand = (text: string): string =>
     homeDir ? text.replace(/(^|[\s(\["'`])~\//g, (_m, pre: string) => `${pre}${homeDir}/`) : text;
-  const combined = tildeExpand(texts.join(' '));
+  const combined = stripUrls(tildeExpand(texts.join(' ')));
 
   // Match absolute paths (Unix) — capture up to 6 path segments.
   // Path segments cannot contain whitespace, /, <>, quotes, or regex
@@ -320,7 +396,7 @@ function extractAllProjectRoots(texts: string[]): Array<{ root: string; votes: n
     (typeof process !== 'undefined' && (process.env.HOME || process.env.USERPROFILE)) || '';
   const tildeExpand = (text: string): string =>
     homeDir ? text.replace(/(^|[\s(\["'`])~\//g, (_m, pre: string) => `${pre}${homeDir}/`) : text;
-  const combined = tildeExpand(texts.join(' '));
+  const combined = stripUrls(tildeExpand(texts.join(' ')));
   // Path segments cannot contain whitespace, /, <>, quotes, or regex
   // metacharacters that show up in source code and config but are never
   // valid in real filesystem paths: ?, ^, $, {, }, [, ], (, ), |, \\, *, +.
@@ -350,7 +426,7 @@ function extractKeySubdirectories(texts: string[], projectRoot: string, limit: n
     (typeof process !== 'undefined' && (process.env.HOME || process.env.USERPROFILE)) || '';
   const tildeExpand = (text: string): string =>
     homeDir ? text.replace(/(^|[\s(\["'`])~\//g, (_m, pre: string) => `${pre}${homeDir}/`) : text;
-  const combined = tildeExpand(texts.join(' '));
+  const combined = stripUrls(tildeExpand(texts.join(' ')));
   const pathRe = /(\/(?:[^\s/<>"'`?^${}\[\]()|\\*+]+\/){1,8}[^\s/<>"'`?^${}\[\]()|\\*+]*)/g;
   const prefix = projectRoot.endsWith('/') ? projectRoot : projectRoot + '/';
   const votes = new Map<string, number>();

--- a/api/src/agent/sessionGrouping.ts
+++ b/api/src/agent/sessionGrouping.ts
@@ -28,6 +28,26 @@ function stripResponseWrappers(text: string): string {
 // Extract user_input text from persisted session history
 // ---------------------------------------------------------------------------
 
+// Strip server-injected wrappers from inside a user message so we don't
+// re-feed them to the classifier on subsequent turns. The agent server
+// prepends <project_context name="..."> ... </project_context> (carrying the
+// previously-classified group's absolute path) to every user turn for an
+// already-grouped session. If we leave that block in the text we send to the
+// LLM and to extractProjectPath, the classifier keeps "seeing" the old
+// project's path inside the user's words and sticks the session to the wrong
+// (often the parent) group forever — even after the user has clearly moved
+// on to a different project. We also strip <stored_instructions> defensively
+// (some clients embed them inline rather than as a separate message) and the
+// outer <user_input> wrapper.
+function stripInjectedWrappers(text: string): string {
+  return text
+    .replace(/<project_context[^>]*>[\s\S]*?<\/project_context>/gi, '')
+    .replace(/<stored_instructions>[\s\S]*?<\/stored_instructions>/gi, '')
+    .replace(/<user_input>([\s\S]*?)<\/user_input>/gi, '$1')
+    .replace(/@omniagent/gi, '')
+    .trim();
+}
+
 function extractUserInputs(historyJson: string): string[] {
   try {
     const history = JSON.parse(historyJson) as Array<{ role: string; content: unknown }>;
@@ -44,13 +64,13 @@ function extractUserInputs(historyJson: string): string[] {
       if (raw.startsWith('Web research is complete')) continue;
       if (raw.startsWith('IMPORTANT: The web search tool failed')) continue;
       if (raw.startsWith('Content was truncated')) continue;
-      if (raw.includes('<stored_instructions>')) continue;
 
-      // Extract the inner text from <user_input> wrapper if present
+      // Extract the inner text from <user_input> wrapper if present, then
+      // strip any server-injected blocks (project_context, stored_instructions)
+      // so the classifier only sees what the user actually typed this turn.
       const match = /<user_input>([\s\S]*?)<\/user_input>/i.exec(raw);
-      const text = match ? match[1].trim() : raw.trim();
-
-      const cleaned = text.replace(/@omniagent\s*/gi, '').trim();
+      const inner = match ? match[1] : raw;
+      const cleaned = stripInjectedWrappers(inner);
       if (cleaned.length > 5) {
         inputs.push(cleaned.slice(0, 400));
       }
@@ -68,40 +88,164 @@ function extractUserInputs(historyJson: string): string[] {
 // root (stops at depth 4 from /, so ~/projects/foo/src/bar → ~/projects/foo).
 // ---------------------------------------------------------------------------
 
+// Path segments that are never a project root on their own — when the deepest
+// scored candidate ends in one of these, we walk up one level. Kept lower-case;
+// matched case-insensitively against the final segment.
+const NON_ROOT_SEGMENTS = new Set([
+  'src',
+  'lib',
+  'libs',
+  'dist',
+  'build',
+  'out',
+  'bin',
+  'obj',
+  'target',
+  'pkg',
+  'cmd',
+  'public',
+  'assets',
+  'static',
+  'node_modules',
+  'test',
+  'tests',
+  '__tests__',
+  'spec',
+  'specs',
+  'docs',
+  'doc',
+  'scripts',
+  'tmp',
+  'temp',
+  'vendor',
+  'third_party',
+  'internal',
+  'pages',
+  'components',
+  'utils',
+  'util',
+  'helpers',
+  'types',
+  '.git',
+  '.github',
+  '.vscode',
+  'node',
+]);
+
+// Top-level OS roots that contain user home directories. The segment
+// immediately after one of these is a username, NOT a project — so we always
+// skip both segments when computing the shallowest legitimate project depth.
+// e.g. /Users/alice/... and /home/alice/... both contribute a project only at
+// depth >= 3.
+const HOME_ROOT_SEGMENTS = new Set(['users', 'home']);
+
+// Generic container directories that sit between a username and the project
+// root and therefore can never themselves BE the project. We walk through any
+// chain of these when determining startDepth.
+// e.g. /Users/alice/Documents/projects/MyApp → /Users/alice/Documents/projects
+// are containers, /MyApp is the first legitimate project segment.
+const HOME_CONTAINER_SEGMENTS = new Set([
+  'documents',
+  'desktop',
+  'downloads',
+  'projects',
+  'workspace',
+  'workspaces',
+  'repos',
+  'code',
+  'dev',
+  'work',
+  'github',
+]);
+
+function looksLikeFile(segment: string): boolean {
+  // Treat a trailing dotted extension (e.g. index.ts, package.json, README.md)
+  // as a file, not a directory. Dotfiles like .gitignore are also files.
+  if (!segment) return false;
+  if (segment.startsWith('.') && segment.length > 1 && !segment.includes('/')) {
+    // .git, .github, .vscode are directories handled by NON_ROOT_SEGMENTS;
+    // .env, .gitignore, .prettierrc are files.
+    const known = new Set(['.git', '.github', '.vscode', '.idea', '.next', '.cache']);
+    return !known.has(segment.toLowerCase());
+  }
+  return /\.[A-Za-z0-9]{1,8}$/.test(segment);
+}
+
+function trimToProjectRoot(path: string): string | null {
+  let parts = path.split('/').filter(Boolean);
+  // Strip a trailing file segment, if any.
+  if (parts.length && looksLikeFile(parts[parts.length - 1])) {
+    parts = parts.slice(0, -1);
+  }
+  // Walk up while the deepest segment is a non-root folder (src, lib, dist, ...).
+  while (parts.length > 1 && NON_ROOT_SEGMENTS.has(parts[parts.length - 1].toLowerCase())) {
+    parts = parts.slice(0, -1);
+  }
+  // A bare /Users/<name> or /home/<name> is not a project — neither is
+  // /Users/<name>/Documents. Require at least one segment past the home
+  // root + username + container chain.
+  let firstProjectIdx = 0;
+  // Skip the OS home-root + its username (e.g. /Users/alice or /home/bob).
+  if (parts.length > 0 && HOME_ROOT_SEGMENTS.has(parts[0].toLowerCase())) {
+    firstProjectIdx = Math.min(2, parts.length);
+  }
+  // Then skip any further generic container segments (Documents, projects, ...).
+  while (
+    firstProjectIdx < parts.length &&
+    HOME_CONTAINER_SEGMENTS.has(parts[firstProjectIdx].toLowerCase())
+  ) {
+    firstProjectIdx++;
+  }
+  if (firstProjectIdx >= parts.length) return null;
+  if (parts.length < 2) return null;
+  return '/' + parts.join('/');
+}
+
 function extractProjectPath(texts: string[]): string | null {
   const combined = texts.join(' ');
 
-  // Match absolute paths (Unix) — capture up to 5 path segments
-  const pathRe = /(\/(?:[^\s/<>"'`]+\/){1,5}[^\s/<>"'`]*)/g;
-  const matches = Array.from(combined.matchAll(pathRe), (m) => m[1]);
+  // Match absolute paths (Unix) — capture up to 6 path segments.
+  const pathRe = /(\/(?:[^\s/<>"'`]+\/){1,6}[^\s/<>"'`]*)/g;
+  const rawMatches = Array.from(combined.matchAll(pathRe), (m) => m[1])
+    // Strip trailing sentence punctuation that the regex greedily included
+    // (e.g. "see /Users/x/MyApp/cli, please edit ..." → /Users/x/MyApp/cli).
+    .map((raw) => raw.replace(/[.,;:!?)\]]+$/, ''))
+    .filter((raw) => raw.length > 1);
+  if (!rawMatches.length) return null;
 
-  if (!matches.length) return null;
+  // Normalise each match to its likely project root (drop trailing file
+  // segment, drop non-root subdirs like src/dist/tests, and bail out on bare
+  // home directories). Each match contributes one vote.
+  const normalised: string[] = [];
+  for (const raw of rawMatches) {
+    const trimmed = trimToProjectRoot(raw);
+    if (trimmed) normalised.push(trimmed);
+  }
+  if (!normalised.length) return null;
 
-  // Score candidate roots by frequency: walk up each path up to depth 5
-  // counting how many times each ancestor appears across all matches.
-  const score = new Map<string, number>();
-  for (const p of matches) {
-    const parts = p.split('/').filter(Boolean);
-    // Build ancestors from depth 2 up to depth 5 (skip / and single-segment)
-    for (let depth = 2; depth <= Math.min(5, parts.length); depth++) {
-      const candidate = '/' + parts.slice(0, depth).join('/');
-      score.set(candidate, (score.get(candidate) ?? 0) + 1);
-    }
+  // Count direct votes for each candidate project root. We deliberately do
+  // NOT roll up votes to ancestors here: the previous implementation did, and
+  // that's exactly how the user's home directory (or a parent project that
+  // happened to enclose every referenced file) was scoring higher than the
+  // actual project the user was working in. Each path votes for exactly one
+  // candidate: its own trimmed project root.
+  const directVotes = new Map<string, number>();
+  for (const path of normalised) {
+    directVotes.set(path, (directVotes.get(path) ?? 0) + 1);
   }
 
-  // Prefer the deepest path that still has a frequency >= half the top score
-  const entries = Array.from(score.entries()).sort((a, b) => b[1] - a[1]);
-  if (!entries.length) return null;
+  // Pick the candidate with the most direct votes. Ties are broken by
+  // preferring the DEEPER path — when two siblings tie, the longer one is the
+  // most-specific common reference and is more likely the project root the
+  // user actually means. If two unrelated paths tie at the top, fall through
+  // and pick the one mentioned first (stable insertion order).
+  const entries = Array.from(directVotes.entries()).sort((a, b) => {
+    if (b[1] !== a[1]) return b[1] - a[1];
+    return b[0].split('/').length - a[0].split('/').length;
+  });
 
-  const topScore = entries[0][1];
-  const threshold = Math.max(1, Math.floor(topScore / 2));
-
-  // Among candidates meeting the threshold, pick the deepest (most segments)
-  const qualified = entries
-    .filter(([, s]) => s >= threshold)
-    .sort((a, b) => b[0].split('/').length - a[0].split('/').length);
-
-  return qualified[0]?.[0] ?? null;
+  const winner = entries[0][0];
+  return trimToProjectRoot(winner) ?? winner;
 }
 
 // ---------------------------------------------------------------------------
@@ -581,3 +725,17 @@ export function startGroupingCronJob(): void {
     }
   })();
 }
+
+// ---------------------------------------------------------------------------
+// Test-only exports. Kept at the bottom of the file and prefixed with __ so
+// they are obviously not part of the public API. The session grouping
+// pipeline runs in a worker process and exercises the LLM, but the path
+// extraction and input cleaning helpers are pure functions that we want
+// thorough unit coverage on — they are the entire defence against the
+// "session grouped under the wrong (often the parent) project" bug.
+export const __testing__ = {
+  extractUserInputs,
+  extractProjectPath,
+  stripInjectedWrappers,
+  trimToProjectRoot,
+};

--- a/api/src/agent/sessionGrouping.ts
+++ b/api/src/agent/sessionGrouping.ts
@@ -32,20 +32,46 @@ function stripResponseWrappers(text: string): string {
 // re-feed them to the classifier on subsequent turns. The agent server
 // prepends <project_context name="..."> ... </project_context> (carrying the
 // previously-classified group's absolute path) to every user turn for an
-// already-grouped session. If we leave that block in the text we send to the
-// LLM and to extractProjectPath, the classifier keeps "seeing" the old
-// project's path inside the user's words and sticks the session to the wrong
-// (often the parent) group forever — even after the user has clearly moved
-// on to a different project. We also strip <stored_instructions> defensively
-// (some clients embed them inline rather than as a separate message) and the
-// outer <user_input> wrapper.
+// already-grouped session. Leaving the WHOLE block in the text we send to
+// the LLM and to extractProjectPath would cause the classifier to keep
+// "seeing" the old project's path inside the user's own words — that is
+// what made wrong groupings sticky forever.
+//
+// But naively stripping the entire block has its own failure mode: when the
+// user types a path-free message like "continue working" or "what about
+// the cron job?", removing <project_context> leaves NO path at all and the
+// LLM is free to hallucinate a new one (we saw it produce things like
+// "/linear.app/coderabbit/issue/..." and "/Users/.../OmniKey-AI/macOS/Sources"
+// after the cron ran). So we now do something more conservative:
+//
+//   1. Pull the "Project root: <abs path>" sentence out of every
+//      <project_context> block before stripping the rest.
+//   2. Append each extracted path back as a plain line. It contributes only
+//      ONE vote to extractProjectPath's frequency count, so any path the user
+//      actually types still wins, but when the user typed nothing path-shaped
+//      we have a deterministic fallback instead of a hallucination.
+//   3. Strip <stored_instructions>, the outer <user_input>, and @omniAgent
+//      the same as before.
 function stripInjectedWrappers(text: string): string {
-  return text
-    .replace(/<project_context[^>]*>[\s\S]*?<\/project_context>/gi, '')
+  const contextPaths: string[] = [];
+  const withContextPathsExtracted = text.replace(
+    /<project_context[^>]*>([\s\S]*?)<\/project_context>/gi,
+    (_full, inner: string) => {
+      const m = /Project root:\s*(\/[^\s.,;:!?)<>"'`]+)/i.exec(inner);
+      if (m) contextPaths.push(m[1]);
+      return '';
+    },
+  );
+  const cleaned = withContextPathsExtracted
     .replace(/<stored_instructions>[\s\S]*?<\/stored_instructions>/gi, '')
     .replace(/<user_input>([\s\S]*?)<\/user_input>/gi, '$1')
     .replace(/@omniagent/gi, '')
     .trim();
+  if (!contextPaths.length) return cleaned;
+  // Re-append context paths as a single low-weight line. Each path appears
+  // once, prefixed so it does not look like the user typed prose.
+  const pathsLine = contextPaths.map((p) => `[context root] ${p}`).join('\n');
+  return cleaned ? `${cleaned}\n${pathsLine}` : pathsLine;
 }
 
 function extractUserInputs(historyJson: string): string[] {
@@ -158,6 +184,21 @@ const HOME_CONTAINER_SEGMENTS = new Set([
   'github',
 ]);
 
+// First-segment patterns that mean a string starting with "/" is a URL or
+// domain that the agent server / a copy-paste accidentally turned into a
+// path-shaped token, NOT a real filesystem root. We reject these entirely
+// from project-root candidacy. Examples seen in the wild:
+//   /github.com/owner/repo/pull/220
+//   /linear.app/coderabbit/issue/REV-19/...
+//   /console.cloud.google.com/run/worker-pools/...
+//   /localhost:5173/dashboard/summary
+//   /apps.apple.com/ca/app/bhabi/id6475659322
+const DOMAINY_FIRST_SEGMENT = /^(?:localhost(?::\d+)?$|[a-z0-9-]+\.[a-z]{2,}(?:\.[a-z]{2,})*$)/i;
+
+function firstSegmentLooksLikeDomain(segment: string): boolean {
+  return DOMAINY_FIRST_SEGMENT.test(segment);
+}
+
 function looksLikeFile(segment: string): boolean {
   // Treat a trailing dotted extension (e.g. index.ts, package.json, README.md)
   // as a file, not a directory. Dotfiles like .gitignore are also files.
@@ -173,6 +214,14 @@ function looksLikeFile(segment: string): boolean {
 
 function trimToProjectRoot(path: string): string | null {
   let parts = path.split('/').filter(Boolean);
+  // Reject URL-shaped pseudo-paths up front. "/github.com/owner/repo" looks
+  // like an absolute path to the regex but it is actually a URL with the
+  // scheme stripped, and we must never treat it as a project root — doing so
+  // is exactly how stale descriptions ended up storing things like
+  // "Project root: /github.com/coderabbitai/grafana/pull/220".
+  if (parts.length > 0 && firstSegmentLooksLikeDomain(parts[0])) {
+    return null;
+  }
   // Strip a trailing file segment, if any.
   if (parts.length && looksLikeFile(parts[parts.length - 1])) {
     parts = parts.slice(0, -1);
@@ -288,8 +337,14 @@ function extractStoredProjectPath(description: string | null | undefined): strin
   if (!description) return null;
   const match = /Project root:\s*(\/[^\s.,;:!?)<>"'`]+)/i.exec(description);
   if (!match) return null;
-  const trimmed = trimToProjectRoot(match[1]);
-  return trimmed ?? match[1];
+  // Only return paths that pass full normalisation. A previously-stored
+  // description may carry a URL-shaped pseudo-path ("/github.com/..." or
+  // "/linear.app/...") from before the URL rejection was added; treating
+  // that as a valid project root would keep mis-merging unrelated sessions.
+  // When the stored path fails normalisation we report "no stored path" so
+  // the path-match short-circuit cannot fire and the LLM/safety nets get a
+  // chance to rewrite the description with a real root.
+  return trimToProjectRoot(match[1]);
 }
 
 /** Pick the existing group whose stored project root EXACTLY equals the
@@ -603,6 +658,18 @@ async function enrichGroupDescription(
   const projectPath = extractProjectPath(allInputs);
   const messagesText = allInputs.map((m, i) => `${i + 1}. ${m}`).join('\n');
 
+  // Hand the LLM the deterministically extracted root explicitly. Before
+  // this, the prompt only said "quote the exact absolute path verbatim when
+  // present" and trusted the LLM to find it in the messages, which is how
+  // we ended up with hallucinated paths like "/linear.app/coderabbit/..."
+  // and "/Users/.../OmniKey-AI/macOS/Sources" surviving multiple cron
+  // refreshes. The downstream safety net still rewrites mismatches, but
+  // giving the LLM the path up front means most calls produce the right
+  // text the first time.
+  const projectPathLine = projectPath
+    ? `Deterministically extracted project root for this group: ${projectPath}\n(Use this EXACT path in the "Project root:" sentence. Do not abbreviate, do not paraphrase, do not substitute a URL for it.)`
+    : 'No absolute project root could be deterministically extracted from the messages. Say "Project root: not specified." in the description.';
+
   const prompt =
     isUpdateMode && existingDescription
       ? `Update the project group description for "${groupName}" based on new session data.
@@ -610,11 +677,13 @@ async function enrichGroupDescription(
 Current description:
 "${existingDescription}"
 
+${projectPathLine}
+
 Recent user messages from sessions in this group:
 ${messagesText}
 
 Update the description to incorporate any new findings. Keep the same 3-4 sentence structure answering in order:
-1. Where is the project root? (Quote the exact absolute path verbatim when present.)
+1. Where is the project root? Use the deterministically extracted path above when one was provided. Never use a URL (github.com/..., linear.app/..., console.cloud.google.com/...) as the project root.
 2. What is the purpose of this project?
 3. What is the primary programming language?
 
@@ -623,11 +692,13 @@ Rules: single paragraph, under ~500 characters, no markdown, no bullet points, n
 Respond with ONLY valid JSON: {"groupDescription":"..."}`
       : `Generate a description for the project group "${groupName}" based on these session messages.
 
+${projectPathLine}
+
 Messages:
 ${messagesText}
 
 Write a SINGLE paragraph of 3-4 sentences (no markdown, no bullet points, no newlines) answering in order:
-1. Where is the project root? (Quote the exact absolute path verbatim when present, or say so if absent.)
+1. Where is the project root? Use the deterministically extracted path above when one was provided; never use a URL.
 2. What is the purpose of this project?
 3. What is the primary programming language? (Name it when inferable; "Primary language not identified." if not.)
 

--- a/api/src/agent/sessionGrouping.ts
+++ b/api/src/agent/sessionGrouping.ts
@@ -767,12 +767,45 @@ export async function updateSessionGroup(sessionId: string, subscriptionId: stri
 // to UPDATE the existing description with any new findings.
 // ---------------------------------------------------------------------------
 
+// In-memory map of when we last refreshed each group's description. Keyed by
+// `${subscriptionId}::${groupName}`. Lost on worker restart, which is fine —
+// the first tick after restart will refresh everything once and then settle
+// into the activity-gated steady state. We deliberately do NOT persist this
+// to the DB: the existing AgentSession.updatedAt covers "was the description
+// touched recently?" if we ever need durable tracking.
+const lastRefreshedAt = new Map<string, Date>();
+
+function refreshKey(subscriptionId: string, groupName: string): string {
+  return `${subscriptionId}::${groupName}`;
+}
+
 async function refreshGroupDescription(
   subscriptionId: string,
   groupName: string,
   existingDescription: string | null,
 ): Promise<void> {
   try {
+    // Skip-if-idle: only refresh when the group has had activity (a new user
+    // turn pushed onto some session's history) since we last refreshed it.
+    // Saves an LLM call per group per tick on quiet groups — the previous
+    // implementation paid that cost forever even when nothing changed.
+    const newest = await AgentSession.findOne({
+      where: { subscriptionId, groupName },
+      order: [['last_active_at', 'DESC']],
+      attributes: ['lastActiveAt'],
+    });
+    if (!newest) return;
+    const lastRefresh = lastRefreshedAt.get(refreshKey(subscriptionId, groupName));
+    if (lastRefresh && newest.lastActiveAt <= lastRefresh) {
+      logger.debug('Group description refresh skipped — no activity since last refresh', {
+        subscriptionId,
+        groupName,
+        lastRefresh,
+        lastActiveAt: newest.lastActiveAt,
+      });
+      return;
+    }
+
     const sessions = await AgentSession.findAll({
       where: { subscriptionId, groupName },
       order: [['last_active_at', 'DESC']],
@@ -806,6 +839,8 @@ async function refreshGroupDescription(
       { where: { subscriptionId, groupName } },
     );
 
+    lastRefreshedAt.set(refreshKey(subscriptionId, groupName), new Date());
+
     logger.info('Group description refreshed', { subscriptionId, groupName });
   } catch (err) {
     logger.error('Failed to refresh group description', { subscriptionId, groupName, error: err });
@@ -816,9 +851,38 @@ async function refreshGroupDescription(
 // Public: refresh all sessions for a subscription (used by cron)
 // ---------------------------------------------------------------------------
 
+// Run an async function over each item in `items` with at most `limit`
+// concurrent executions. Used to parallelise per-group refresh and
+// per-session backfill within a subscription without unbounded fan-out
+// against the LLM provider.
+async function runWithConcurrency<T>(
+  items: readonly T[],
+  limit: number,
+  fn: (item: T) => Promise<void>,
+): Promise<void> {
+  const queue = items.slice();
+  const workers: Promise<void>[] = [];
+  const worker = async (): Promise<void> => {
+    while (queue.length > 0) {
+      const item = queue.shift();
+      if (item === undefined) return;
+      try {
+        await fn(item);
+      } catch (err) {
+        // Individual item failures are logged inside `fn`; we keep draining
+        // the queue so one bad item never blocks the rest of the tick.
+        logger.error('runWithConcurrency item failed', { error: err });
+      }
+    }
+  };
+  for (let i = 0; i < Math.max(1, limit); i++) workers.push(worker());
+  await Promise.all(workers);
+}
+
 export async function refreshAllSessionGroups(subscriptionId: string): Promise<void> {
   try {
-    // Refresh descriptions for all existing groups (one LLM call per group).
+    // Refresh descriptions for all existing groups (one LLM call per group,
+    // gated by the per-group skip-if-idle check inside refreshGroupDescription).
     const groupRows = await AgentSession.findAll({
       where: {
         subscriptionId,
@@ -828,16 +892,10 @@ export async function refreshAllSessionGroups(subscriptionId: string): Promise<v
       group: ['group_name'],
     });
 
-    logger.info('Refreshing session groups', {
-      subscriptionId,
-      groupCount: groupRows.length,
-    });
-
-    for (const row of groupRows) {
-      await refreshGroupDescription(subscriptionId, row.groupName!, row.groupDescription ?? null);
-    }
-
-    // Also classify any sessions that haven't been grouped yet.
+    // Ungrouped sessions: classify any that have never been grouped yet.
+    // Limited to the 20 most recently active so a long-quiet account with
+    // thousands of historical ungrouped sessions still makes forward progress
+    // tick by tick instead of blowing past the LLM rate limit on the first run.
     const ungroupedSessions = await AgentSession.findAll({
       where: { subscriptionId, groupName: null },
       order: [['last_active_at', 'DESC']],
@@ -845,9 +903,24 @@ export async function refreshAllSessionGroups(subscriptionId: string): Promise<v
       attributes: ['id'],
     });
 
-    for (const session of ungroupedSessions) {
-      await updateSessionGroup(session.id, subscriptionId);
-    }
+    logger.info('Refreshing session groups', {
+      subscriptionId,
+      groupCount: groupRows.length,
+      ungroupedCount: ungroupedSessions.length,
+    });
+
+    // Refresh + backfill run in parallel (each with bounded concurrency) so
+    // that a slow refresh doesn't delay backfill for the same subscription.
+    // Concurrency is intentionally low (3) to avoid bursting the upstream
+    // LLM provider when a subscription has many groups.
+    await Promise.allSettled([
+      runWithConcurrency(groupRows, 3, async (row) => {
+        await refreshGroupDescription(subscriptionId, row.groupName!, row.groupDescription ?? null);
+      }),
+      runWithConcurrency(ungroupedSessions, 3, async (session) => {
+        await updateSessionGroup(session.id, subscriptionId);
+      }),
+    ]);
   } catch (err) {
     logger.error('Failed to refresh session groups for subscription', {
       subscriptionId,
@@ -857,49 +930,70 @@ export async function refreshAllSessionGroups(subscriptionId: string): Promise<v
 }
 
 // ---------------------------------------------------------------------------
-// Cron: run every 6 hours across all subscriptions
+// Cron: run hourly across all subscriptions.
+//
+// Each tick:
+//   1. Lists every subscription.
+//   2. For each subscription, refreshes existing group descriptions (gated by
+//      activity since last refresh — quiet groups cost nothing) and classifies
+//      up to 20 ungrouped sessions.
+//
+// Per-tick invariants:
+//   - Only one tick runs at a time. If a tick exceeds the interval, the next
+//     one is skipped instead of overlapping (overlap caused duplicate LLM
+//     calls and racy AgentSession.update writes in the previous version).
+//   - Subscriptions are processed concurrently with a small concurrency cap.
+//   - An initial tick runs ~5 seconds after worker boot so sessions written
+//     while the worker was down do not have to wait a full hour to be
+//     grouped. Previously the boot-time backfill only ran when ZERO sessions
+//     had ever been grouped, which silently regressed on every restart of a
+//     normal account.
 // ---------------------------------------------------------------------------
 
-export function startGroupingCronJob(): void {
-  const ONE_HOUR_MS = 60 * 60 * 1_000;
+export const GROUPING_TICK_INTERVAL_MS = 60 * 60 * 1_000;
+export const GROUPING_INITIAL_TICK_DELAY_MS = 5_000;
+export const GROUPING_SUBSCRIPTION_CONCURRENCY = 3;
 
-  const tick = async () => {
+export function startGroupingCronJob(): void {
+  let tickInFlight = false;
+
+  const tick = async (): Promise<void> => {
+    if (tickInFlight) {
+      logger.warn('Skipping session grouping tick — previous tick still running');
+      return;
+    }
+    tickInFlight = true;
+    const startedAt = Date.now();
     try {
       const subscriptions = await Subscription.findAll({ attributes: ['id'] });
       logger.info('Running session grouping cron', {
         subscriptionCount: subscriptions.length,
       });
-      for (const sub of subscriptions) {
+      await runWithConcurrency(subscriptions, GROUPING_SUBSCRIPTION_CONCURRENCY, async (sub) => {
         await refreshAllSessionGroups(sub.id);
-      }
+      });
+      logger.info('Session grouping cron tick completed', {
+        durationMs: Date.now() - startedAt,
+      });
     } catch (err) {
       logger.error('Session grouping cron failed', { error: err });
+    } finally {
+      tickInFlight = false;
     }
   };
 
-  setInterval(() => void tick(), ONE_HOUR_MS);
-  logger.info('Session grouping cron started (1h interval)');
+  setInterval(() => void tick(), GROUPING_TICK_INTERVAL_MS);
+  logger.info('Session grouping cron started', {
+    intervalMs: GROUPING_TICK_INTERVAL_MS,
+  });
 
-  // If no session has a group yet (e.g. first startup after the feature was
-  // added, or a fresh self-hosted install with existing sessions), run the
-  // full backfill immediately rather than waiting 1 hours.
-  void (async () => {
-    try {
-      const ungrouped = await AgentSession.count({ where: { groupName: null } });
-      const grouped = await AgentSession.count({ where: { groupName: { [Op.not]: null } } });
-      logger.info(
-        `Session grouping backfill check: ${ungrouped} ungrouped sessions, ${grouped} grouped sessions`,
-      );
-      if (ungrouped > 0 && grouped === 0) {
-        logger.info('No sessions have a group yet — running initial grouping backfill', {
-          sessionCount: ungrouped,
-        });
-        await tick();
-      }
-    } catch (err) {
-      logger.error('Initial grouping backfill check failed', { error: err });
-    }
-  })();
+  // Always run an initial tick shortly after boot. We deliberately schedule
+  // it (small delay) rather than awaiting it inline so worker bootstrap
+  // returns immediately and the parent process can mark the worker healthy.
+  // The previous "only if zero sessions have ever been grouped" gate meant
+  // any restart of a real account would leave new ungrouped sessions
+  // unclassified for up to an hour.
+  setTimeout(() => void tick(), GROUPING_INITIAL_TICK_DELAY_MS);
 }
 
 // ---------------------------------------------------------------------------
@@ -917,4 +1011,7 @@ export const __testing__ = {
   extractStoredProjectPath,
   findGroupByExactPath,
   classifyGroup,
+  runWithConcurrency,
+  refreshGroupDescription,
+  lastRefreshedAt,
 };

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "omnikey-cli",
-  "version": "1.6.10",
+  "version": "1.6.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "omnikey-cli",
-      "version": "1.6.10",
+      "version": "1.6.11",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.96.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -4,7 +4,7 @@
     "access": "public",
     "registry": "https://registry.npmjs.org/"
   },
-  "version": "1.6.10",
+  "version": "1.6.11",
   "description": "CLI for onboarding users to Omnikey AI and configuring OPENAI_API_KEY. Use Yarn for install/build.",
   "engines": {
     "node": ">=14.0.0",

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -26,7 +26,7 @@ const program = new Command();
 program
   .name('omnikey')
   .description('Omnikey CLI for onboarding and configuration')
-  .version('1.6.9');
+  .version('1.6.11');
 
 program
   .command('onboard')


### PR DESCRIPTION
## Problem

Sessions were getting filed under the **wrong project group** — typically a parent repo (e.g. `OmniKey-AI`) — even when the user was clearly working in a sibling or child project. Once a session was grouped wrong it stayed wrong forever. Separately, the hourly cron was both **expensive** (one LLM call per group per hour, forever) and **slow to recover** after a worker restart. Running the new cron against real sqlite then exposed a third class of bug: descriptions kept getting refreshed with hallucinated URL-shaped paths.

This PR fixes all three layers of `api/src/agent/sessionGrouping.ts`:

1. **Deterministic side** — `extractUserInputs` / `extractProjectPath` (commit 1)
2. **LLM side** — `classifyGroup` / `enrichGroupDescription` (commit 2)
3. **Cron side** — `refreshGroupDescription` / `refreshAllSessionGroups` / `startGroupingCronJob` (commit 3)
4. **Production-observed hallucinations** — URL pseudo-paths and path-free user turns (commit 4)

---

## Commit 1 — deterministic helpers

### Root cause

**A. `<project_context>` leak in `extractUserInputs`** — The agent server prepends `<project_context name="...">` (carrying the previously-classified group's absolute path) to every user turn of an already-grouped session — see `agentServer.ts:557`. `extractUserInputs` was extracting the inner text of `<user_input>` but not stripping the injected block, so the classifier kept "seeing" the old path on every subsequent turn, making any wrong grouping self-reinforcing.

**B. Ancestor-rollup + deepest-wins in `extractProjectPath`** — The scoring rolled votes up to every ancestor, letting `/Users/<name>` or an enclosing parent repo accumulate one vote per child path and beat the real project.

### Fix

- `stripInjectedWrappers` removes `<project_context>`, `<stored_instructions>`, `<user_input>`, `@omniAgent`.
- `trimToProjectRoot` + `HOME_ROOT_SEGMENTS` + `HOME_CONTAINER_SEGMENTS` + `NON_ROOT_SEGMENTS` normalise each matched path.
- `extractProjectPath` counts **direct votes only** (no ancestor rollup) with deeper-wins tie-break and trailing-punctuation stripping.

---

## Commit 2 — LLM classification

### Root cause

1. `classifyGroup` matched existing groups **by name only**.
2. The LLM prompt showed only existing group **names** with no indication of which path each one represented.
3. Post-LLM accepted any name match unconditionally.
4. `enrichGroupDescription` let the LLM keep a hallucinated `Project root:` path in the description verbatim — and that description IS the `<project_context>` injected on every next turn.

### Fix

- `extractStoredProjectPath` recovers the project root from a stored group description.
- `findGroupByExactPath` matches existing groups by **exact path equality only** — ancestor/descendant matches do NOT count.
- `classifyGroup` short-circuits on exact path match **before calling the LLM**.
- The LLM prompt now shows each existing group's stored root and the current session's detected root, with explicit ancestor/descendant rules.
- Post-LLM, mismatched name-vs-path is rejected; a new name is derived from the deepest path segment.
- Both `classifyGroup` and `enrichGroupDescription` **rewrite** any `Project root:` sentence whose path disagrees with the deterministic extraction.

---

## Commit 3 — cron job

### Root causes

1. Boot backfill **only ran when `grouped === 0`** — any restart of a normal account silently waited a full hour.
2. **No overlap guard** on `setInterval`.
3. **Strict serial processing** of subscriptions and per-subscription groups.
4. **No skip-if-idle** — refresh ran an LLM call per group per tick, forever.

### Fix

- `runWithConcurrency<T>` helper with bounded concurrency + per-item error isolation.
- `startGroupingCronJob` always schedules an initial tick ~5s after boot, guards via `tickInFlight`, iterates subscriptions with concurrency 3, logs tick duration.
- `refreshAllSessionGroups` runs **group refresh and ungrouped backfill independently in parallel**.
- `refreshGroupDescription` consults an in-memory `lastRefreshedAt` map and skips the LLM when the group's newest `lastActiveAt` is older than the last successful refresh.
- Cron timing constants exported.

---

## Commit 4 — production-observed hallucinations

Running the new cron against real sqlite produced these descriptions:

| Group | Stored "Project root:" | Reality |
|---|---|---|
| OmniKey AI | `/Users/.../OmniKey-AI/macOS/Sources` | Should be `/Users/.../OmniKey-AI` |
| CodeRabbit AI | `/linear.app/coderabbit/issue/REV-19/...` | URL, not a path |
| CodeRabbit UI | `/localhost:5173/dashboard/summary` | URL, not a path |
| Bhabi UI | `/apps.apple.com/ca/app/bhabi/...` | URL, not a path |
| General | `/console.cloud.google.com/run/...` | URL, not a path |

### Root causes

1. **`<project_context>` was stripped entirely.** Path-free user turns ("continue working on the task", "check the cron job") left `extractProjectPath` with no anchor; the LLM was free to invent any root and the safety net never fired (it only fires when `extractProjectPath` returns a value).
2. **`trimToProjectRoot` accepted URL-shaped pseudo-paths.** `/github.com/...`, `/linear.app/...`, `/console.cloud.google.com/...`, `/localhost:5173/...` matched the absolute-path regex but are not filesystem paths.
3. **`extractStoredProjectPath` fell through to the raw regex** when normalisation rejected the stored path. A previously stored URL-shaped "root" still acted as a valid path-match key, keeping wrong groupings sticky across refreshes.

### Fix

- `stripInjectedWrappers` now surgically pulls the `Project root: <path>` sentence out of every `<project_context>` block BEFORE stripping the rest, and re-appends it as a tagged `[context root] <path>` line. One vote in `extractProjectPath`'s frequency count — typed paths still win, but path-free turns get a deterministic fallback instead of a hallucination.
- New `DOMAINY_FIRST_SEGMENT` check in `trimToProjectRoot` rejects any path whose top segment looks like a hostname or `localhost:<port>`.
- `extractStoredProjectPath` now returns `null` when normalisation rejects the stored path, so the LLM/safety nets get a chance to rewrite the description.
- `enrichGroupDescription` now hands the LLM the deterministic project root explicitly in the prompt (`Use this EXACT path in the "Project root:" sentence`). The downstream rewrite still runs, but most refreshes now produce the right text on the first try.

---

## Tests

`api/src/__tests__/sessionGrouping.test.ts` — **52 unit tests** total:

| Area | Tests |
| --- | --- |
| `stripInjectedWrappers` (incl. `[context root]` preservation) | 5 |
| `extractUserInputs` | 4 |
| `trimToProjectRoot` | 6 |
| `extractProjectPath` (incl. parent/child regression) | 10 |
| Production-observed regressions (URLs, path-free turns) | 4 |
| `extractStoredProjectPath` (incl. URL rejection) | 6 |
| `findGroupByExactPath` | 4 |
| `classifyGroup` (LLM mocked) | 5 |
| `runWithConcurrency` | 5 |
| `refreshGroupDescription` | 3 |

## Verification

```
$ cd api && yarn test --run src/__tests__/sessionGrouping.test.ts
 ✓ src/__tests__/sessionGrouping.test.ts (52 tests) 25ms
 Test Files  1 passed (1)
      Tests  52 passed (52)

$ yarn build
$ tsc
Done in 1.36s.

$ npx prettier --check ...
All matched files use Prettier code style!
```

Full `yarn test` shows 3 pre-existing failures in `ai-client.adapters.test.ts` (OpenAI Responses API streaming mock) that also fail on `main` — unrelated to this change.

## Files changed

- `api/src/agent/sessionGrouping.ts`
- `api/src/__tests__/sessionGrouping.test.ts` (new)

## Assumptions / limitations

- `<project_context>` block format is stable.
- Description shape (`Project root: <abs path>.` as the first sentence) written by this module is stable; older-shape descriptions fall back to "stored path unknown" in the LLM prompt and still classify correctly via deterministic path.
- `lastRefreshedAt` is in-memory only. After restart we pay one LLM call per group to repopulate it, then return to the idle-skip steady state.
- `app`/`apps` were intentionally NOT added to `NON_ROOT_SEGMENTS` to avoid mis-trimming projects literally named `App`.
- Existing groups in production carry stale descriptions (some with URL "roots"). With this change, on the **next activity-triggered refresh** of each group:
  - `extractStoredProjectPath` returns `null` for the URL "root"
  - `extractProjectPath` finds the real path (either typed by the user or carried in as a `[context root]` line)
  - `enrichGroupDescription` writes a new description with the real path
  - subsequent turns lock in correctly via the path-match short-circuit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Large new test suite covering session grouping, project-root extraction, description refreshes, truncation/sentence-boundary behavior, local-path filtering, and production-observed regressions.

* **Refactor**
  * Stronger, more reliable project-root detection and vote-based root selection; safer group classification and description enrichment to prevent hallucinated roots; improved refresh scheduling with concurrency and straggler demotion handling.

* **Chores**
  * Version bumps for API and CLI and updated CLI displayed version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->