### PR TITLE
feat(windows): Usage dashboard, chat model switcher, DB-backed agent settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ A quick reference of the core capabilities and the commands or shortcuts that dr
   omnikey telegram stop
   ```
 
+  In Telegram, use `/cmd` to start or resume an agent task, `/model` to change the active provider's agent model, `/task` to fetch progress or the last result, and `/stop` to abort a running session.
+
 - **Scheduled Jobs** — automate recurring or one-time prompt runs from the desktop app or the CLI (`omnikey schedule add` / `list` / `remove`).
 
 ## The @omniAgent

--- a/api/public/index.html
+++ b/api/public/index.html
@@ -619,6 +619,7 @@
               <strong>Telegram</strong> from your phone or any device. Run the daemon and the
               Telegram client on your machine, leave it running, and drive entire agent sessions
               from Telegram. Use <code>/cmd</code> to start or resume a task via a guided wizard,
+              <code>/model</code> to choose the active provider&rsquo;s agent model,
               <code>/task</code> to check progress or fetch the last result, and <code>/stop</code>
               to abort a running session. The bot runs as a persistent background daemon (launchd on
               macOS, NSSM on Windows) managed entirely through the CLI.
@@ -993,7 +994,14 @@ omnikey mcp update &lt;id&gt;</code></pre>
                 are accepted only from your configured chat ID.
               </p>
               <ul class="provider-list">
-                <li><code>/cmd</code> — guided wizard to start or resume an agent session</li>
+                <li>
+                  <code>/cmd</code> — guided wizard to start or resume an agent session, including
+                  model selection before the prompt
+                </li>
+                <li>
+                  <code>/model</code> — choose the active provider&rsquo;s agent model without
+                  starting a task
+                </li>
                 <li>
                   <code>/cmd --verbose</code> — stream shell output, web calls, and MCP events as
                   they happen

--- a/api/src/__tests__/usageRoutes.tokenMetrics.test.ts
+++ b/api/src/__tests__/usageRoutes.tokenMetrics.test.ts
@@ -16,6 +16,7 @@
 
 import express from 'express';
 import request from 'supertest';
+import { Op } from 'sequelize';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import winston from 'winston';
 
@@ -172,6 +173,47 @@ describe('GET /api/usage — token metrics', () => {
       expect.objectContaining({ id: 'sess_recent', totalTokens: 4_000, turns: 3 }),
       expect.objectContaining({ id: 'sess_old', totalTokens: 1_500, turns: 1 }),
     ]);
+  });
+
+  it('buckets daily usage with the requested local time zone', async () => {
+    mocks.usageFindAll.mockResolvedValue([usageRow(900, 100, '2026-07-29T00:30:00Z')]);
+
+    const res = await request(makeApp()).get(
+      '/api/usage?range=7d&to=2026-07-29T00:45:00Z&timeZone=America/Toronto',
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.range.timeZone).toBe('America/Toronto');
+    expect(res.body.daily).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          key: '2026-07-28',
+          promptTokens: 900,
+          completionTokens: 100,
+          totalTokens: 1_000,
+          requests: 1,
+        }),
+      ]),
+    );
+    expect(
+      res.body.daily.some(
+        (bucket: { key: string; totalTokens: number }) =>
+          bucket.key === '2026-07-29' && bucket.totalTokens > 0,
+      ),
+    ).toBe(false);
+  });
+
+  it('uses local month boundaries for range=month', async () => {
+    const res = await request(makeApp()).get(
+      '/api/usage?range=month&to=2026-07-29T00:30:00Z&timeZone=America/Toronto',
+    );
+
+    const where = mocks.usageFindAll.mock.calls[0][0].where as Record<string, any>;
+    const createdAt = where.createdAt as Record<symbol, Date>;
+    expect(createdAt[Op.gte].toISOString()).toBe('2026-07-01T04:00:00.000Z');
+    expect(createdAt[Op.lt].toISOString()).toBe('2026-07-29T00:30:00.000Z');
+    expect(res.body.range.days).toBe(28);
+    expect(res.body.range.timeZone).toBe('America/Toronto');
   });
 
   it('reports zeroed totals and no NaN average when there is no usage', async () => {

--- a/api/src/usageRoutes.ts
+++ b/api/src/usageRoutes.ts
@@ -43,6 +43,15 @@ type AgentSessionSummary = {
   lastActiveAt: Date;
 };
 
+type ZonedDateParts = {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+  second: number;
+};
+
 function normalizeProvider(provider: string | null | undefined): string {
   return provider && provider.trim() ? provider.trim() : 'unknown';
 }
@@ -104,31 +113,140 @@ function addToBucket(bucket: UsageBucket, row: UsageRow): void {
   bucket.requests += 1;
 }
 
-function startOfDay(date: Date): Date {
-  const d = new Date(date);
-  d.setHours(0, 0, 0, 0);
-  return d;
-}
-
-function addDays(date: Date, days: number): Date {
-  const d = new Date(date);
-  d.setDate(d.getDate() + days);
-  return d;
-}
-
-function daysBetween(start: Date, end: Date): number {
-  const ms = Math.max(0, end.getTime() - start.getTime());
-  return Math.max(1, Math.ceil(ms / 86_400_000));
-}
-
 function parseDateValue(value: unknown): Date | null {
   if (typeof value !== 'string') return null;
   const date = new Date(value);
   return Number.isNaN(date.getTime()) ? null : date;
 }
 
-function dayKey(date: Date): string {
-  return date.toISOString().slice(0, 10);
+function parseTimeZone(query: express.Request['query']): string {
+  const fallback = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+  const value = typeof query.timeZone === 'string' ? query.timeZone.trim() : '';
+  if (!value) return fallback;
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: value }).format(new Date());
+    return value;
+  } catch {
+    return fallback;
+  }
+}
+
+function zonedParts(date: Date, timeZone: string): ZonedDateParts {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hourCycle: 'h23',
+  }).formatToParts(date);
+
+  const get = (type: string): number => {
+    const value = parts.find((part) => part.type === type)?.value;
+    return value ? Number(value) : 0;
+  };
+
+  return {
+    year: get('year'),
+    month: get('month'),
+    day: get('day'),
+    hour: get('hour'),
+    minute: get('minute'),
+    second: get('second'),
+  };
+}
+
+function pad2(value: number): string {
+  return String(value).padStart(2, '0');
+}
+
+function localDayKeyFromParts(parts: Pick<ZonedDateParts, 'year' | 'month' | 'day'>): string {
+  return `${parts.year}-${pad2(parts.month)}-${pad2(parts.day)}`;
+}
+
+function dayKey(date: Date, timeZone: string): string {
+  return localDayKeyFromParts(zonedParts(date, timeZone));
+}
+
+function parseDayKey(key: string): Pick<ZonedDateParts, 'year' | 'month' | 'day'> {
+  const [year, month, day] = key.split('-').map(Number);
+  return { year, month, day };
+}
+
+function addCalendarDays(key: string, days: number): string {
+  const { year, month, day } = parseDayKey(key);
+  const date = new Date(Date.UTC(year, month - 1, day + days));
+  return localDayKeyFromParts({
+    year: date.getUTCFullYear(),
+    month: date.getUTCMonth() + 1,
+    day: date.getUTCDate(),
+  });
+}
+
+function calendarDaysBetween(startKey: string, endKey: string): number {
+  const start = parseDayKey(startKey);
+  const end = parseDayKey(endKey);
+  const startMs = Date.UTC(start.year, start.month - 1, start.day);
+  const endMs = Date.UTC(end.year, end.month - 1, end.day);
+  return Math.floor((endMs - startMs) / 86_400_000);
+}
+
+function zonedDateTimeToUtc(
+  parts: Pick<ZonedDateParts, 'year' | 'month' | 'day'> &
+    Partial<Pick<ZonedDateParts, 'hour' | 'minute' | 'second'>>,
+  timeZone: string,
+): Date {
+  const target = {
+    year: parts.year,
+    month: parts.month,
+    day: parts.day,
+    hour: parts.hour ?? 0,
+    minute: parts.minute ?? 0,
+    second: parts.second ?? 0,
+  };
+  const targetAsUtc = Date.UTC(
+    target.year,
+    target.month - 1,
+    target.day,
+    target.hour,
+    target.minute,
+    target.second,
+  );
+  let utcMs = targetAsUtc;
+
+  for (let i = 0; i < 3; i++) {
+    const actual = zonedParts(new Date(utcMs), timeZone);
+    const actualAsUtc = Date.UTC(
+      actual.year,
+      actual.month - 1,
+      actual.day,
+      actual.hour,
+      actual.minute,
+      actual.second,
+    );
+    const diff = actualAsUtc - targetAsUtc;
+    if (diff === 0) break;
+    utcMs -= diff;
+  }
+
+  return new Date(utcMs);
+}
+
+function addLocalDays(date: Date, days: number, timeZone: string): Date {
+  const parts = zonedParts(date, timeZone);
+  const shifted = parseDayKey(addCalendarDays(localDayKeyFromParts(parts), days));
+  return zonedDateTimeToUtc(
+    { ...shifted, hour: parts.hour, minute: parts.minute, second: parts.second },
+    timeZone,
+  );
+}
+
+function localDaySpan(from: Date, to: Date, timeZone: string): number {
+  const startKey = dayKey(from, timeZone);
+  const endKey = dayKey(to, timeZone);
+  return Math.max(1, calendarDaysBetween(startKey, endKey) + 1);
 }
 
 function aggregateBy(
@@ -146,16 +264,21 @@ function aggregateBy(
   return Array.from(map.values()).sort((a, b) => b.totalTokens - a.totalTokens);
 }
 
-function buildDaily(rows: UsageRow[], from: Date | null, to: Date): UsageBucket[] {
+function buildDaily(
+  rows: UsageRow[],
+  from: Date | null,
+  to: Date,
+  timeZone: string,
+): UsageBucket[] {
   const map = new Map<string, UsageBucket>();
   if (from) {
-    for (let d = startOfDay(from); d <= to; d = addDays(d, 1)) {
-      const key = dayKey(d);
+    const endKey = dayKey(to, timeZone);
+    for (let key = dayKey(from, timeZone); key <= endKey; key = addCalendarDays(key, 1)) {
       map.set(key, emptyBucket(key, key));
     }
   }
   for (const row of rows) {
-    const key = dayKey(row.createdAt);
+    const key = dayKey(row.createdAt, timeZone);
     const bucket = map.get(key) ?? emptyBucket(key, key);
     addToBucket(bucket, row);
     map.set(key, bucket);
@@ -191,7 +314,10 @@ function buildRecentSessions(
     }));
 }
 
-function parseRange(query: express.Request['query']): {
+function parseRange(
+  query: express.Request['query'],
+  timeZone: string,
+): {
   label: string;
   from: Date | null;
   to: Date;
@@ -203,7 +329,12 @@ function parseRange(query: express.Request['query']): {
   const range = typeof query.range === 'string' ? query.range : '30d';
 
   if (explicitFrom) {
-    return { label: 'Custom', from: explicitFrom, to, days: daysBetween(explicitFrom, to) };
+    return {
+      label: 'Custom',
+      from: explicitFrom,
+      to,
+      days: localDaySpan(explicitFrom, to, timeZone),
+    };
   }
 
   if (range === 'all') {
@@ -213,13 +344,14 @@ function parseRange(query: express.Request['query']): {
   }
 
   if (range === 'month') {
-    const from = new Date(to.getFullYear(), to.getMonth(), 1);
-    return { label: 'This month', from, to, days: daysBetween(from, to) };
+    const parts = zonedParts(to, timeZone);
+    const from = zonedDateTimeToUtc({ year: parts.year, month: parts.month, day: 1 }, timeZone);
+    return { label: 'This month', from, to, days: localDaySpan(from, to, timeZone) };
   }
 
   const match = range.match(/^(\d+)d$/);
   const days = match ? Math.max(1, Math.min(365, Number(match[1]))) : 30;
-  return { label: `Last ${days} days`, from: addDays(to, -days), to, days };
+  return { label: `Last ${days} days`, from: addLocalDays(to, -days, timeZone), to, days };
 }
 
 function parseProviderFilter(query: express.Request['query']): string | null {
@@ -257,9 +389,9 @@ function toUsageRows(rawRows: SubscriptionUsage[]): UsageRow[] {
  * length; "all time" falls back to the number of distinct days that actually
  * have recorded usage so a single old call does not flatten the average.
  */
-function countedDays(rows: UsageRow[], rangeDays: number): number {
+function countedDays(rows: UsageRow[], rangeDays: number, timeZone: string): number {
   if (rangeDays > 0) return rangeDays;
-  const distinctDays = new Set(rows.map((row) => dayKey(startOfDay(row.createdAt)))).size;
+  const distinctDays = new Set(rows.map((row) => dayKey(row.createdAt, timeZone))).size;
   return Math.max(1, distinctDays);
 }
 
@@ -268,7 +400,8 @@ export function createUsageRouter(): express.Router {
 
   router.get('/', authMiddleware, async (req, res) => {
     const { subscription, logger: log } = res.locals;
-    const range = parseRange(req.query);
+    const timeZone = parseTimeZone(req.query);
+    const range = parseRange(req.query, timeZone);
     const providerFilter = parseProviderFilter(req.query);
 
     try {
@@ -297,8 +430,8 @@ export function createUsageRouter(): express.Router {
 
       const rows = toUsageRows(rawRows);
       const totals = summarizeRows(rows);
-      const days = countedDays(rows, range.days);
-      const daily = buildDaily(rows, range.from, range.to);
+      const days = countedDays(rows, range.days, timeZone);
+      const daily = buildDaily(rows, range.from, range.to, timeZone);
 
       res.json({
         recordingEnabled: agentSettings.usageRecordingEnabled,
@@ -308,6 +441,7 @@ export function createUsageRouter(): express.Router {
           from: range.from?.toISOString() ?? null,
           to: range.to.toISOString(),
           days,
+          timeZone,
         },
         provider: {
           provider: providerFilter ?? 'all',

--- a/cli/README.md
+++ b/cli/README.md
@@ -262,6 +262,8 @@ The `omnikey telegram` command group runs a Telegram bot as a persistent backgro
 
 For setup instructions (creating a bot, finding your chat ID, and configuring credentials) see the [Telegram README](../telegram/README.md).
 
+Inside Telegram, use `/cmd` to start or resume an agent task, `/model` to pick the active provider's agent model, `/task` to check progress or fetch the last result, and `/stop` to abort the running session. The `/cmd` wizard also includes a model-selection step before collecting the prompt.
+
 ### `omnikey telegram start`
 
 Installs and starts the daemon. If `TELEGRAM_BOT_TOKEN` or `TELEGRAM_CHAT_ID` are not yet saved, the CLI prompts for them, validates the token against the Telegram API, and saves them to `~/.omnikey/config.json` before installing the service. On macOS the bot runs as a **launchd agent**; on Windows as an **NSSM service**. Both auto-restart on crash and start automatically on login.

--- a/macOS/Sources/APIClient.swift
+++ b/macOS/Sources/APIClient.swift
@@ -1381,7 +1381,10 @@ final class APIClient: @unchecked Sendable {
         completion: @escaping @Sendable (Result<UsageMetricsResponse, Error>) -> Void
     ) {
         var components = URLComponents(url: usageBaseURL, resolvingAgainstBaseURL: false)
-        var queryItems = [URLQueryItem(name: "range", value: range)]
+        var queryItems = [
+            URLQueryItem(name: "range", value: range),
+            URLQueryItem(name: "timeZone", value: TimeZone.current.identifier),
+        ]
         if let provider, provider != "all" {
             queryItems.append(URLQueryItem(name: "provider", value: provider))
         }

--- a/macOS/Sources/ManualView.swift
+++ b/macOS/Sources/ManualView.swift
@@ -196,7 +196,8 @@ struct ManualView: View {
                             bulletRow(text: "Install and start the Telegram bot daemon:")
                             examplePill("omnikey telegram start")
                             bulletRow(text: "On first run the CLI asks for your bot token (from @BotFather) and chat ID, validates the token, and saves both to ~/.omnikey/config.json.")
-                            bulletRow(text: "/cmd — start or resume a task via a guided wizard.")
+                            bulletRow(text: "/cmd — start or resume a task via a guided wizard with model selection.")
+                            bulletRow(text: "/model — change the active provider's agent model.")
                             bulletRow(text: "/task — check progress or fetch the last result.")
                             bulletRow(text: "/stop — abort a running session.")
                         }

--- a/telegram/README.md
+++ b/telegram/README.md
@@ -101,9 +101,12 @@ Opens a guided wizard to start a new session or resume a recent one.
 **Wizard steps:**
 
 1. **Session** — pick a recent session to resume, or start a new one.
-2. **Instructions** — pick a saved task template to set as the active default, or skip.
-3. **Project** — pick a project for context, or skip.
-4. **Prompt** — send your prompt as the next plain-text message.
+2. **Model** — pick the model for the active provider, or keep the current model.
+3. **Instructions** — pick a saved task template to set as the active default, or skip.
+4. **Project** — pick a project for context, or skip.
+5. **Prompt** — send your prompt as the next plain-text message.
+
+When resuming an existing session, the wizard picks a model first and then goes straight to the prompt.
 
 Each step is presented as an inline keyboard. Tap **✕ Cancel** at any point to abort.
 
@@ -115,6 +118,16 @@ Add `--verbose` (or `-v`) to also receive shell commands, terminal output, web c
 
 ```
 /cmd --verbose
+```
+
+---
+
+### `/model` — Change the agent model
+
+Shows an inline picker for the currently active AI provider. Choosing a model updates that provider's agent model in the OmniKey daemon, so the next Telegram agent turn uses the selected model.
+
+```
+/model
 ```
 
 ---
@@ -150,4 +163,3 @@ Sends an abort signal to the running agent turn. The session stops cleanly and y
 | Commands are silently ignored | Message is coming from a chat ID that doesn't match `TELEGRAM_CHAT_ID` |
 | Daemon not running | Check `omnikey telegram status` and `omnikey telegram logs` |
 | Nothing listening on port | Confirm `omnikey daemon` is running; check `omnikey status` |
-

--- a/telegram/src/agentClient.ts
+++ b/telegram/src/agentClient.ts
@@ -112,6 +112,104 @@ export async function listProjectGroups(logger: Logger): Promise<ProjectGroup[]>
   return resp.data?.groups ?? [];
 }
 
+export interface AgentModelOption {
+  readonly id: string;
+  readonly label: string;
+}
+
+export interface AIProviderListResponse {
+  readonly activeProvider: string;
+  readonly activeModel?: string | null;
+  readonly modelOptions?: AgentModelOption[];
+  readonly supportsCustomModel?: boolean;
+}
+
+export interface AIProviderMutationResponse {
+  readonly provider: string;
+  readonly model?: string | null;
+  readonly activeModel?: string | null;
+  readonly modelOptions?: AgentModelOption[];
+  readonly supportsCustomModel?: boolean;
+}
+
+const FALLBACK_AGENT_MODEL_OPTIONS: Record<string, AgentModelOption[]> = {
+  openai: [
+    { id: 'gpt-5.6', label: 'GPT 5.6' },
+    { id: 'gpt-5.5', label: 'GPT 5.5' },
+    { id: 'gpt-5.1', label: 'GPT 5.1' },
+    { id: 'gpt-4.1', label: 'GPT 4.1' },
+  ],
+  anthropic: [
+    { id: 'claude-opus-4-5', label: 'Claude Opus 4.5' },
+    { id: 'claude-opus-4-7', label: 'Claude Opus 4.7' },
+    { id: 'claude-opus-5', label: 'Claude Opus 5.0' },
+    { id: 'claude-sonnet-4-5', label: 'Claude Sonnet 4.5' },
+    { id: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6' },
+    { id: 'claude-sonnet-5', label: 'Claude Sonnet 5.0' },
+    { id: 'claude-fable-5', label: 'Claude Fable 5.0' },
+  ],
+  gemini: [
+    { id: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro' },
+    { id: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash' },
+  ],
+  nemotron: [
+    {
+      id: 'nvidia/nemotron-3-ultra-550b-a55b',
+      label: 'nvidia/nemotron-3-ultra-550b-a55b',
+    },
+    {
+      id: 'nvidia/nemotron-3-super-120b-a12b',
+      label: 'nvidia/nemotron-3-super-120b-a12b',
+    },
+    {
+      id: 'nvidia/nemotron-3-nano-30b-a3b',
+      label: 'nvidia/nemotron-3-nano-30b-a3b',
+    },
+  ],
+};
+
+function fallbackModelOptions(provider: string): AgentModelOption[] {
+  return FALLBACK_AGENT_MODEL_OPTIONS[provider] ?? FALLBACK_AGENT_MODEL_OPTIONS.openai;
+}
+
+export async function fetchAIProviders(logger: Logger): Promise<AIProviderListResponse> {
+  const token = await fetchJwtToken(logger);
+  const url = `${omnikeyBaseUrl()}/api/providers`;
+  const resp = await axios.get<AIProviderListResponse>(url, {
+    timeout: 10_000,
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  const activeProvider = resp.data?.activeProvider || 'openai';
+  const modelOptions =
+    resp.data?.modelOptions && resp.data.modelOptions.length > 0
+      ? resp.data.modelOptions
+      : fallbackModelOptions(activeProvider);
+  return {
+    ...resp.data,
+    activeProvider,
+    modelOptions,
+    activeModel: resp.data?.activeModel ?? modelOptions[0]?.id ?? null,
+  };
+}
+
+export async function updateProviderModel(
+  logger: Logger,
+  provider: string,
+  model: string,
+): Promise<AIProviderMutationResponse> {
+  const token = await fetchJwtToken(logger);
+  const url = `${omnikeyBaseUrl()}/api/providers/${encodeURIComponent(provider)}/model`;
+  const resp = await axios.patch<AIProviderMutationResponse>(
+    url,
+    { model },
+    {
+      timeout: 10_000,
+      headers: { Authorization: `Bearer ${token}` },
+    },
+  );
+  return resp.data;
+}
+
 // Wire-format mirrors omnikey-ai/src/agent/types.ts AgentMessage.
 interface AgentWireMessage {
   session_id: string;
@@ -171,6 +269,12 @@ function extractTagged(content: string, tag: string): string | null {
   return m?.[1]?.trim() || null;
 }
 
+function extractTaggedRaw(content: string, tag: string): string | null {
+  const re = new RegExp(`<${tag}[^>]*>([\\s\\S]*?)<\\/${tag}>`, 'i');
+  const m = content.match(re);
+  return m ? m[1] : null;
+}
+
 function stripTagged(content: string, tag: string): string {
   return content.replace(new RegExp(`<${tag}[^>]*>[\\s\\S]*?<\\/${tag}>`, 'gi'), '');
 }
@@ -184,6 +288,7 @@ function cleanReasoning(content: string): string {
 
 const SHELL_TIMEOUT_MS = 20 * 60 * 1000;
 const SHELL_OUTPUT_MAX = 64 * 1024;
+const AGENT_IDLE_TIMEOUT_MS = 30 * 60 * 1000;
 
 // Mirrors WINDOWS_SHELL_CANDIDATES in src/agent/mcpRuntime.ts
 const WINDOWS_SHELL_CANDIDATES = [
@@ -337,9 +442,26 @@ export async function runAgentTurn(logger: Logger, opts: RunAgentOptions): Promi
     });
 
     let settled = false;
+    let idleTimer: NodeJS.Timeout | null = null;
+
+    const resetIdleTimer = () => {
+      if (idleTimer) clearTimeout(idleTimer);
+      idleTimer = setTimeout(() => {
+        logger.warn('Agent WebSocket run timed out with no progress', {
+          sessionId,
+          timeoutMs: AGENT_IDLE_TIMEOUT_MS,
+        });
+        finish(new Error('Agent run timed out with no progress. Try again or send /task to inspect the latest session state.'));
+      }, AGENT_IDLE_TIMEOUT_MS);
+    };
+
     const finish = (err: Error | null, result?: RunAgentResult) => {
       if (settled) return;
       settled = true;
+      if (idleTimer) {
+        clearTimeout(idleTimer);
+        idleTimer = null;
+      }
       if (opts.signal && onAbort) {
         opts.signal.removeEventListener('abort', onAbort);
       }
@@ -370,6 +492,7 @@ export async function runAgentTurn(logger: Logger, opts: RunAgentOptions): Promi
 
     ws.on('open', () => {
       logger.info('Agent WebSocket open', { sessionId });
+      resetIdleTimer();
       send({
         session_id: sessionId,
         sender: 'client',
@@ -393,6 +516,7 @@ export async function runAgentTurn(logger: Logger, opts: RunAgentOptions): Promi
       }
 
       const content = msg.content || '';
+      resetIdleTimer();
 
       if (msg.is_error) {
         finish(new Error(content || 'Agent reported an error'));
@@ -419,10 +543,31 @@ export async function runAgentTurn(logger: Logger, opts: RunAgentOptions): Promi
         return;
       }
 
-      const shellScript = extractTagged(content, 'shell_script');
-      if (shellScript) {
+      const rawShellScript = extractTaggedRaw(content, 'shell_script');
+      if (rawShellScript !== null) {
+        const shellScript = rawShellScript.trim();
         const reasoning = cleanReasoning(stripTagged(content, 'shell_script'));
         if (reasoning) await opts.onBlock({ kind: 'reasoning', text: reasoning });
+
+        if (!shellScript) {
+          const message =
+            'COMMAND ERROR: The agent requested an empty shell_script. No command was executed. Please respond with a corrected non-empty shell_script or a <final_answer>.';
+          logger.warn('Agent requested empty shell_script; returning command error', { sessionId });
+          await opts.onBlock({
+            kind: 'terminalOutput',
+            text: `[terminal error]\n${message}`,
+          });
+          send({
+            session_id: sessionId,
+            sender: 'client',
+            content: message,
+            is_terminal_output: true,
+            is_error: true,
+            platform: PLATFORM,
+          });
+          return;
+        }
+
         await opts.onBlock({ kind: 'shellCommand', text: shellScript });
 
         try {

--- a/telegram/src/notifyTelegram.ts
+++ b/telegram/src/notifyTelegram.ts
@@ -2,12 +2,15 @@ import TelegramBot from 'node-telegram-bot-api';
 import type { Logger } from 'winston';
 import {
   AgentAbortError,
+  fetchAIProviders,
   getSessionMessages,
   listProjectGroups,
   listRecentSessions,
   listTaskTemplates,
   runAgentTurn,
   setDefaultTaskTemplate,
+  updateProviderModel,
+  type AgentModelOption,
   type AgentSessionSummary,
   type ProjectGroup,
   type TaskTemplate,
@@ -52,7 +55,7 @@ export async function notify(
 
 // ─── /cmd flow state ─────────────────────────────────────────────────────────
 
-type WizardPhase = 'selectInstruction' | 'selectProject' | 'awaitPrompt';
+type WizardPhase = 'selectModel' | 'selectInstruction' | 'selectProject' | 'awaitPrompt';
 
 interface PendingPromptState {
   phase: WizardPhase;
@@ -63,10 +66,14 @@ interface PendingPromptState {
   /** Cached lists so callbacks can resolve indices without size-limited tokens. */
   templates: TaskTemplate[];
   groups: ProjectGroup[];
+  modelOptions: AgentModelOption[];
+  activeProvider: string;
+  activeModel: string | null;
   /** Resolved selections, applied when the user finally sends the prompt. */
   chosenInstructions: string | null;
   chosenInstructionsHeading: string | null;
   chosenGroupName: string | null;
+  chosenModelLabel: string | null;
   /** When true, surface every agent block (shell/web/mcp/image) instead of
    *  only reasoning + final answer. Toggled by `/cmd --verbose`. */
   verbose: boolean;
@@ -80,12 +87,20 @@ interface RunningSessionState {
   stoppedByUser: boolean;
 }
 
+interface ModelSelectionState {
+  activeProvider: string;
+  activeModel: string | null;
+  modelOptions: AgentModelOption[];
+}
+
 const pendingPrompts = new Map<number, PendingPromptState>();
 const runningSessions = new Map<number, RunningSessionState>();
 
 // Callback-data prefixes. Telegram limits callback_data to 64 bytes — using
 // short prefixes + indices keeps every payload comfortably under the cap.
 const CB_SESSION = 's:'; // session picker; "s:new" or "s:<idx>"
+const CB_MODEL = 'm:'; // model picker;   "m:skip" or "m:<idx>"
+const CB_MODEL_ONLY = 'mo:'; // standalone /model picker; "mo:skip" or "mo:<idx>"
 const CB_INSTRUCTION = 't:'; // instruction picker; "t:skip" or "t:<idx>"
 const CB_PROJECT = 'g:'; // project picker;     "g:skip" or "g:<idx>"
 const CB_CANCEL = 'x:cancel';
@@ -336,6 +351,35 @@ function buildProjectKeyboard(groups: ProjectGroup[]): TelegramBot.InlineKeyboar
   return rows;
 }
 
+function buildModelKeyboard(
+  options: AgentModelOption[],
+  activeModel: string | null,
+  prefix = CB_MODEL,
+): TelegramBot.InlineKeyboardButton[][] {
+  const rows: TelegramBot.InlineKeyboardButton[][] = [];
+  options.forEach((option, idx) => {
+    const marker = option.id === activeModel ? '✓' : '🤖';
+    rows.push([
+      {
+        text: `${marker}  ${truncate(option.label || option.id, 50)}`,
+        callback_data: `${prefix}${idx}`,
+      },
+    ]);
+  });
+  rows.push([{ text: '⏭  Keep current model', callback_data: `${prefix}skip` }]);
+  rows.push([{ text: '✕  Cancel', callback_data: CB_CANCEL }]);
+  return rows;
+}
+
+function modelLabelFor(state: PendingPromptState, model: string | null): string {
+  if (!model) return 'current model';
+  return state.modelOptions.find((option) => option.id === model)?.label ?? model;
+}
+
+function wizardStep(state: PendingPromptState, step: number): string {
+  return `Step ${step} of ${state.sessionId ? 2 : 4}`;
+}
+
 // ─── Wizard step rendering ───────────────────────────────────────────────────
 
 interface WizardCopy {
@@ -343,14 +387,38 @@ interface WizardCopy {
   readonly keyboard: TelegramBot.InlineKeyboardButton[][];
 }
 
+function renderModelStep(state: PendingPromptState): WizardCopy {
+  const currentLabel = modelLabelFor(state, state.activeModel);
+  const heading = `*${wizardStep(state, 1)} · Model*`;
+  const contextLine = state.sessionId ? `Resuming session \`${state.sessionId}\`.` : 'Starting a new session.';
+  const text = [
+    heading,
+    contextLine,
+    `Active provider: *${state.activeProvider}*`,
+    `Current model: *${currentLabel}*`,
+    '',
+    state.modelOptions.length > 0
+      ? 'Pick the model for the next turn, or keep the current one.'
+      : 'No model list was returned. Keep the current model to continue.',
+  ].join('\n');
+
+  return {
+    text,
+    keyboard: buildModelKeyboard(state.modelOptions, state.activeModel),
+  };
+}
+
 function renderInstructionStep(state: PendingPromptState): WizardCopy {
   if (state.templates.length === 0) {
     return {
       text: [
-        '*Step 1 of 3 · Task instructions*',
+        `*${wizardStep(state, 2)} · Task instructions*`,
+        state.chosenModelLabel ? `✓ Model: *${state.chosenModelLabel}*` : '',
         '',
         '_No saved templates. Skip to continue._',
-      ].join('\n'),
+      ]
+        .filter(Boolean)
+        .join('\n'),
       keyboard: [
         [
           {
@@ -364,10 +432,13 @@ function renderInstructionStep(state: PendingPromptState): WizardCopy {
   }
   return {
     text: [
-      '*Step 1 of 3 · Task instructions*',
+      `*${wizardStep(state, 2)} · Task instructions*`,
+      state.chosenModelLabel ? `✓ Model: *${state.chosenModelLabel}*` : '',
       '',
       'Pick a saved template to prepend to your prompt, or skip.',
-    ].join('\n'),
+    ]
+      .filter(Boolean)
+      .join('\n'),
     keyboard: buildInstructionKeyboard(state.templates),
   };
 }
@@ -379,9 +450,15 @@ function renderProjectStep(state: PendingPromptState): WizardCopy {
 
   if (state.groups.length === 0) {
     return {
-      text: ['*Step 2 of 3 · Project*', heading, '', '_No projects yet. Skip to continue._'].join(
-        '\n',
-      ),
+      text: [
+        `*${wizardStep(state, 3)} · Project*`,
+        state.chosenModelLabel ? `✓ Model: *${state.chosenModelLabel}*` : '',
+        heading,
+        '',
+        '_No projects yet. Skip to continue._',
+      ]
+        .filter(Boolean)
+        .join('\n'),
       keyboard: [
         [{ text: '⏭  Skip project', callback_data: `${CB_PROJECT}skip` }],
         [{ text: '✕  Cancel', callback_data: CB_CANCEL }],
@@ -389,25 +466,38 @@ function renderProjectStep(state: PendingPromptState): WizardCopy {
     };
   }
   return {
-    text: ['*Step 2 of 3 · Project*', heading, '', 'Pick a project for context, or skip.'].join(
-      '\n',
-    ),
+    text: [
+      `*${wizardStep(state, 3)} · Project*`,
+      state.chosenModelLabel ? `✓ Model: *${state.chosenModelLabel}*` : '',
+      heading,
+      '',
+      'Pick a project for context, or skip.',
+    ]
+      .filter(Boolean)
+      .join('\n'),
     keyboard: buildProjectKeyboard(state.groups),
   };
 }
 
 function renderPromptStep(state: PendingPromptState): WizardCopy {
   const lines = [
-    '*Step 3 of 3 · Prompt*',
-    state.chosenInstructionsHeading
+    `*${wizardStep(state, state.sessionId ? 2 : 4)} · Prompt*`,
+    state.chosenModelLabel ? `✓ Model: *${state.chosenModelLabel}*` : '',
+    !state.sessionId && state.chosenInstructionsHeading
       ? `✓ Instructions: *${state.chosenInstructionsHeading}*`
-      : '✓ Instructions: _skipped_',
-    state.chosenGroupName ? `✓ Project: *${state.chosenGroupName}*` : '✓ Project: _skipped_',
+      : !state.sessionId
+        ? '✓ Instructions: _skipped_'
+        : '',
+    !state.sessionId && state.chosenGroupName
+      ? `✓ Project: *${state.chosenGroupName}*`
+      : !state.sessionId
+        ? '✓ Project: _skipped_'
+        : '',
     '',
     'Send your prompt as the next message.',
   ];
   return {
-    text: lines.join('\n'),
+    text: lines.filter(Boolean).join('\n'),
     keyboard: [[{ text: '✕  Cancel', callback_data: CB_CANCEL }]],
   };
 }
@@ -415,11 +505,13 @@ function renderPromptStep(state: PendingPromptState): WizardCopy {
 async function showStep(logger: Logger, chatId: number, state: PendingPromptState): Promise<void> {
   if (!bot) return;
   const copy =
-    state.phase === 'selectInstruction'
-      ? renderInstructionStep(state)
-      : state.phase === 'selectProject'
-        ? renderProjectStep(state)
-        : renderPromptStep(state);
+    state.phase === 'selectModel'
+      ? renderModelStep(state)
+      : state.phase === 'selectInstruction'
+        ? renderInstructionStep(state)
+        : state.phase === 'selectProject'
+          ? renderProjectStep(state)
+          : renderPromptStep(state);
 
   if (state.wizardMessageId == null) {
     const sent = await bot.sendMessage(chatId, copy.text, {
@@ -497,6 +589,7 @@ async function sendSessionPicker(
 
 async function handleCmdCommand(logger: Logger, chatId: number, verbose: boolean) {
   pendingPrompts.delete(chatId);
+  modelSelectionCache.delete(chatId);
   pendingVerbose.set(chatId, verbose);
   try {
     const sessions = await listRecentSessions(logger, 5);
@@ -517,6 +610,62 @@ const sessionListCache = new Map<number, AgentSessionSummary[]>();
 // chatId -> verbose flag captured at /cmd time, applied when the user picks
 // a session (new or resume) so the flag survives the async picker step.
 const pendingVerbose = new Map<number, boolean>();
+
+// chatId -> last standalone /model option list shown, for index resolution.
+const modelSelectionCache = new Map<number, ModelSelectionState>();
+
+async function loadModelSelection(logger: Logger): Promise<ModelSelectionState> {
+  try {
+    const providerState = await fetchAIProviders(logger);
+    return {
+      activeProvider: providerState.activeProvider || 'openai',
+      activeModel: providerState.activeModel ?? providerState.modelOptions?.[0]?.id ?? null,
+      modelOptions: providerState.modelOptions ?? [],
+    };
+  } catch (err) {
+    logger.warn('Failed to load model options for Telegram wizard', {
+      error: (err as Error).message,
+    });
+    return {
+      activeProvider: 'openai',
+      activeModel: null,
+      modelOptions: [],
+    };
+  }
+}
+
+async function handleModelCommand(logger: Logger, chatId: number) {
+  if (!bot) return;
+  const selection = await loadModelSelection(logger);
+  modelSelectionCache.set(chatId, selection);
+  const currentLabel =
+    selection.modelOptions.find((option) => option.id === selection.activeModel)?.label ??
+    selection.activeModel ??
+    'current model';
+
+  await bot.sendMessage(
+    chatId,
+    [
+      '*Agent model*',
+      `Active provider: *${selection.activeProvider}*`,
+      `Current model: *${currentLabel}*`,
+      '',
+      selection.modelOptions.length > 0
+        ? 'Pick a model for the next agent turn.'
+        : 'No model list was returned by the daemon.',
+    ].join('\n'),
+    {
+      parse_mode: 'Markdown',
+      reply_markup: {
+        inline_keyboard: buildModelKeyboard(
+          selection.modelOptions,
+          selection.activeModel,
+          CB_MODEL_ONLY,
+        ),
+      },
+    },
+  );
+}
 
 async function handleTaskCommand(logger: Logger, chatId: number) {
   // 1. If a session is currently running for this chat, show last reasoning.
@@ -586,8 +735,11 @@ async function startNewSessionWizard(logger: Logger, chatId: number) {
   if (!bot) return;
   let templates: TaskTemplate[] = [];
   let groups: ProjectGroup[] = [];
+  let activeProvider = 'openai';
+  let activeModel: string | null = null;
+  let modelOptions: AgentModelOption[] = [];
   try {
-    [templates, groups] = await Promise.all([
+    const [templateRows, groupRows, modelSelection] = await Promise.all([
       listTaskTemplates(logger).catch((e) => {
         logger.warn('Failed to load task templates', {
           error: (e as Error).message,
@@ -600,7 +752,13 @@ async function startNewSessionWizard(logger: Logger, chatId: number) {
         });
         return [] as ProjectGroup[];
       }),
+      loadModelSelection(logger),
     ]);
+    templates = templateRows;
+    groups = groupRows;
+    activeProvider = modelSelection.activeProvider;
+    activeModel = modelSelection.activeModel;
+    modelOptions = modelSelection.modelOptions;
   } catch (err) {
     logger.error('Failed to load wizard data', {
       error: (err as Error).message,
@@ -608,14 +766,18 @@ async function startNewSessionWizard(logger: Logger, chatId: number) {
   }
 
   const state: PendingPromptState = {
-    phase: 'selectInstruction',
+    phase: 'selectModel',
     sessionId: null,
     wizardMessageId: null,
     templates,
     groups,
+    modelOptions,
+    activeProvider,
+    activeModel,
     chosenInstructions: null,
     chosenInstructionsHeading: null,
     chosenGroupName: null,
+    chosenModelLabel: null,
     verbose: pendingVerbose.get(chatId) ?? false,
   };
   pendingPrompts.set(chatId, state);
@@ -625,32 +787,24 @@ async function startNewSessionWizard(logger: Logger, chatId: number) {
 async function startResumeSession(logger: Logger, chatId: number, sessionId: string) {
   if (!bot) return;
   const verbose = pendingVerbose.get(chatId) ?? false;
+  const modelSelection = await loadModelSelection(logger);
   const state: PendingPromptState = {
-    phase: 'awaitPrompt',
+    phase: 'selectModel',
     sessionId,
     wizardMessageId: null,
     templates: [],
     groups: [],
+    modelOptions: modelSelection.modelOptions,
+    activeProvider: modelSelection.activeProvider,
+    activeModel: modelSelection.activeModel,
     chosenInstructions: null,
     chosenInstructionsHeading: null,
     chosenGroupName: null,
+    chosenModelLabel: null,
     verbose,
   };
   pendingPrompts.set(chatId, state);
-  await bot.sendMessage(
-    chatId,
-    [
-      `*Resuming session* \`${sessionId}\`${verbose ? ' · 🔍 _verbose_' : ''}`,
-      '',
-      'Send your prompt as the next message.',
-    ].join('\n'),
-    {
-      parse_mode: 'Markdown',
-      reply_markup: {
-        inline_keyboard: [[{ text: '✕  Cancel', callback_data: CB_CANCEL }]],
-      },
-    },
-  );
+  await showStep(logger, chatId, state);
 }
 
 async function handleCallbackQuery(logger: Logger, query: TelegramBot.CallbackQuery) {
@@ -668,6 +822,7 @@ async function handleCallbackQuery(logger: Logger, query: TelegramBot.CallbackQu
     pendingPrompts.delete(chatId);
     sessionListCache.delete(chatId);
     pendingVerbose.delete(chatId);
+    modelSelectionCache.delete(chatId);
     if (state?.wizardMessageId) {
       await finishWizardMessage(chatId, state, '✕  Cancelled.');
     }
@@ -697,7 +852,121 @@ async function handleCallbackQuery(logger: Logger, query: TelegramBot.CallbackQu
     return;
   }
 
-  // Step 1 — instruction picker
+  // Standalone /model picker
+  if (data.startsWith(CB_MODEL_ONLY)) {
+    const state = modelSelectionCache.get(chatId);
+    if (!state) {
+      await bot.answerCallbackQuery(query.id, { text: 'Model picker expired' });
+      return;
+    }
+
+    const tok = data.slice(CB_MODEL_ONLY.length);
+    if (tok === 'skip') {
+      modelSelectionCache.delete(chatId);
+      await bot.answerCallbackQuery(query.id, { text: 'Kept current model' });
+      if (query.message) {
+        await bot.editMessageReplyMarkup(
+          { inline_keyboard: [] },
+          { chat_id: chatId, message_id: query.message.message_id },
+        ).catch(() => undefined);
+      }
+      return;
+    }
+
+    const idx = Number(tok);
+    const option = Number.isInteger(idx) ? state.modelOptions[idx] : undefined;
+    if (!option) {
+      await bot.answerCallbackQuery(query.id, { text: 'Model not found' });
+      return;
+    }
+
+    try {
+      const response = await updateProviderModel(logger, state.activeProvider, option.id);
+      const activeModel = response.activeModel ?? response.model ?? option.id;
+      const options =
+        response.modelOptions && response.modelOptions.length > 0
+          ? response.modelOptions
+          : state.modelOptions;
+      const label =
+        options.find((candidate) => candidate.id === activeModel)?.label ??
+        option.label ??
+        activeModel;
+      modelSelectionCache.delete(chatId);
+      await bot.answerCallbackQuery(query.id, { text: 'Model updated' });
+      if (query.message) {
+        await bot.editMessageText(
+          [
+            '✅ *Agent model updated*',
+            `Active provider: *${state.activeProvider}*`,
+            `Model: *${label}*`,
+          ].join('\n'),
+          {
+            chat_id: chatId,
+            message_id: query.message.message_id,
+            parse_mode: 'Markdown',
+            reply_markup: { inline_keyboard: [] },
+          },
+        );
+      }
+    } catch (err) {
+      logger.error('Failed to update Telegram /model selection', {
+        provider: state.activeProvider,
+        model: option.id,
+        error: (err as Error).message,
+      });
+      await bot.answerCallbackQuery(query.id, { text: 'Failed to update model' });
+    }
+    return;
+  }
+
+  // Wizard step 1 — model picker
+  if (data.startsWith(CB_MODEL)) {
+    const state = pendingPrompts.get(chatId);
+    if (!state || state.phase !== 'selectModel') {
+      await bot.answerCallbackQuery(query.id, { text: 'Step expired' });
+      return;
+    }
+
+    const tok = data.slice(CB_MODEL.length);
+    if (tok === 'skip') {
+      state.chosenModelLabel = modelLabelFor(state, state.activeModel);
+    } else {
+      const idx = Number(tok);
+      const option = Number.isInteger(idx) ? state.modelOptions[idx] : undefined;
+      if (!option) {
+        await bot.answerCallbackQuery(query.id, { text: 'Model not found' });
+        return;
+      }
+
+      try {
+        if (option.id !== state.activeModel) {
+          const response = await updateProviderModel(logger, state.activeProvider, option.id);
+          state.activeModel = response.activeModel ?? response.model ?? option.id;
+          if (response.modelOptions && response.modelOptions.length > 0) {
+            state.modelOptions = response.modelOptions;
+          }
+        } else {
+          state.activeModel = option.id;
+        }
+        state.chosenModelLabel = modelLabelFor(state, state.activeModel) || option.label || option.id;
+      } catch (err) {
+        logger.error('Failed to update Telegram-selected model', {
+          provider: state.activeProvider,
+          model: option.id,
+          error: (err as Error).message,
+        });
+        await bot.answerCallbackQuery(query.id, { text: 'Failed to update model' });
+        return;
+      }
+    }
+
+    state.phase = state.sessionId ? 'awaitPrompt' : 'selectInstruction';
+    await bot.answerCallbackQuery(query.id);
+    await showStep(logger, chatId, state);
+    return;
+  }
+
+  // Wizard step 2 — instruction picker
   if (data.startsWith(CB_INSTRUCTION)) {
     const state = pendingPrompts.get(chatId);
     if (!state || state.phase !== 'selectInstruction') {
@@ -741,7 +1010,7 @@ async function handleCallbackQuery(logger: Logger, query: TelegramBot.CallbackQu
     return;
   }
 
-  // Step 2 — project picker
+  // Wizard step 3 — project picker
   if (data.startsWith(CB_PROJECT)) {
     const state = pendingPrompts.get(chatId);
     if (!state || state.phase !== 'selectProject') {
@@ -786,10 +1055,17 @@ async function runAgentForChat(
   if (pending.wizardMessageId) {
     const summary = [
       '✅ *Session started*',
-      pending.chosenInstructionsHeading
+      pending.chosenModelLabel ? `🤖 Model: *${pending.chosenModelLabel}*` : '',
+      !pending.sessionId && pending.chosenInstructionsHeading
         ? `📝 Instructions: *${pending.chosenInstructionsHeading}*`
-        : '📝 Instructions: _none_',
-      pending.chosenGroupName ? `📁 Project: *${pending.chosenGroupName}*` : '📁 Project: _none_',
+        : !pending.sessionId
+          ? '📝 Instructions: _none_'
+          : '',
+      !pending.sessionId && pending.chosenGroupName
+        ? `📁 Project: *${pending.chosenGroupName}*`
+        : !pending.sessionId
+          ? '📁 Project: _none_'
+          : '',
       pending.verbose ? '🔍 Verbose: *on*' : '',
     ]
       .filter(Boolean)
@@ -1001,6 +1277,11 @@ export function setupMessageListener(logger: Logger, bot: TelegramBot) {
 
     if (lower === '/task') {
       await handleTaskCommand(logger, chatId);
+      return;
+    }
+
+    if (lower === '/model') {
+      await handleModelCommand(logger, chatId);
       return;
     }
 

--- a/windows/ApiClient.cs
+++ b/windows/ApiClient.cs
@@ -20,6 +20,15 @@ namespace OmniKey.Windows
         public bool IsDefault { get; set; }
     }
 
+    /// <summary>One selectable agent model for the active provider. Mirrors
+    /// the server's <c>AgentModelOption</c> (see api/src/agentSettingsStore.ts
+    /// AGENT_MODEL_OPTIONS) and macOS <c>APIClient.AgentModelOptionDTO</c>.</summary>
+    internal sealed class AgentModelOptionDto
+    {
+        public string Id { get; set; } = "";
+        public string Label { get; set; } = "";
+    }
+
     internal sealed class AIProviderDto
     {
         public string Provider { get; set; } = "";
@@ -27,6 +36,18 @@ namespace OmniKey.Windows
         public string? ApiKeyMasked { get; set; }
         public string? BaseUrl { get; set; }
         public string? Model { get; set; }
+
+        /// <summary>Models the server offers for this provider. Empty means the
+        /// provider has no curated list (the caller falls back to a local one).</summary>
+        public List<AgentModelOptionDto> ModelOptions { get; set; } = new();
+
+        /// <summary>Server flag: whether a model picker should be shown at all.
+        /// Derived from <c>modelOptions.length &gt; 0</c> server-side.</summary>
+        public bool SupportsModelSelection { get; set; }
+
+        /// <summary>Server flag: whether an arbitrary model id may be typed in
+        /// (all providers currently allow it).</summary>
+        public bool SupportsCustomModel { get; set; } = true;
     }
 
     internal sealed class AIProviderListResponse
@@ -34,6 +55,15 @@ namespace OmniKey.Windows
         public List<AIProviderDto> Providers { get; set; } = new();
         public string ActiveProvider { get; set; } = "openai";
         public string? RuntimeProvider { get; set; }
+
+        /// <summary>Model currently persisted (in the agent_settings table) for
+        /// the active provider. Drives the chat composer's model pill.</summary>
+        public string? ActiveModel { get; set; }
+
+        /// <summary>Curated options for the *active* provider only.</summary>
+        public List<AgentModelOptionDto> ModelOptions { get; set; } = new();
+
+        public bool SupportsCustomModel { get; set; } = true;
     }
 
     internal sealed class AIProviderMutationResponse
@@ -45,6 +75,14 @@ namespace OmniKey.Windows
         public string? ActiveProvider { get; set; }
         public bool? RestartScheduled { get; set; }
         public string? Message { get; set; }
+
+        /// <summary>Echo of the model that was saved (PATCH .../model).</summary>
+        public string? Model { get; set; }
+
+        /// <summary>Model now active for the active provider after the mutation.</summary>
+        public string? ActiveModel { get; set; }
+
+        public List<AgentModelOptionDto>? ModelOptions { get; set; }
     }
 
     internal sealed class AppSettingsDto
@@ -52,8 +90,19 @@ namespace OmniKey.Windows
         public string TerminalAccess { get; set; } = "limited";
         public bool WebSearchEnabled { get; set; }
         public bool BrowserAccessEnabled { get; set; }
+
+        /// <summary>Whether per-call token rows are persisted. Backed by the
+        /// <c>agent_settings.usage_recording_enabled</c> column (no longer an
+        /// environment variable) and read by the Usage page.</summary>
+        public bool UsageRecordingEnabled { get; set; }
+
         public string? BrowserDebugBrowserName { get; set; }
         public int? BrowserDebugPort { get; set; }
+
+        /// <summary>Where the daemon read these values from. The backend now
+        /// reports "database"; older builds reported the config file. Surfaced
+        /// in the UI so users can tell the DB-backed store is live.</summary>
+        public string? Source { get; set; }
     }
 
     internal sealed class AppSettingsMutationResponse
@@ -61,8 +110,73 @@ namespace OmniKey.Windows
         public string TerminalAccess { get; set; } = "limited";
         public bool WebSearchEnabled { get; set; }
         public bool BrowserAccessEnabled { get; set; }
+        public bool UsageRecordingEnabled { get; set; }
         public bool? RestartScheduled { get; set; }
         public string? Message { get; set; }
+    }
+
+    // ─── Usage metrics (GET /api/usage) ───────────────────────────────
+    // Shapes mirror macOS APIClient.Usage*DTO one-for-one. Cost fields were
+    // deliberately dropped server-side, so these are token counters only.
+
+    internal sealed class UsageTotalsDto
+    {
+        public int PromptTokens { get; set; }
+        public int CompletionTokens { get; set; }
+        public int TotalTokens { get; set; }
+        public int Requests { get; set; }
+    }
+
+    internal sealed class UsageBucketDto
+    {
+        public string Key { get; set; } = "";
+        public string Label { get; set; } = "";
+        public int PromptTokens { get; set; }
+        public int CompletionTokens { get; set; }
+        public int TotalTokens { get; set; }
+        public int Requests { get; set; }
+    }
+
+    internal sealed class UsageRangeDto
+    {
+        public string Label { get; set; } = "";
+        public string? From { get; set; }
+        public string To { get; set; } = "";
+        public int Days { get; set; }
+    }
+
+    internal sealed class UsageProviderDto
+    {
+        public string Provider { get; set; } = "all";
+        public string ProviderLabel { get; set; } = "All Providers";
+    }
+
+    internal sealed class UsageEstimatesDto
+    {
+        public double AverageDailyTokens { get; set; }
+    }
+
+    internal sealed class UsageSessionDto
+    {
+        public string Id { get; set; } = "";
+        public string Title { get; set; } = "";
+        public int Turns { get; set; }
+        public int TotalTokens { get; set; }
+        public string LastActiveAt { get; set; } = "";
+    }
+
+    internal sealed class UsageMetricsResponse
+    {
+        public bool RecordingEnabled { get; set; }
+        public string GeneratedAt { get; set; } = "";
+        public UsageRangeDto Range { get; set; } = new();
+        public UsageProviderDto Provider { get; set; } = new();
+        public UsageTotalsDto Totals { get; set; } = new();
+        public UsageEstimatesDto Estimates { get; set; } = new();
+        public List<UsageBucketDto> ByProvider { get; set; } = new();
+        public List<UsageBucketDto> ByModel { get; set; } = new();
+        public List<UsageBucketDto> Daily { get; set; } = new();
+        public List<UsageSessionDto> RecentSessions { get; set; } = new();
     }
 
     internal sealed class BrowserAccessMutationResponse
@@ -573,19 +687,41 @@ namespace OmniKey.Windows
                    ?? new AppSettingsDto();
         }
 
-        /// <summary>PATCH /api/app-settings — partial update of terminalAccess
-        /// and/or webSearchEnabled (each omitted when null).</summary>
+        /// <summary>PATCH /api/app-settings — partial update of terminalAccess,
+        /// webSearchEnabled and/or usageRecordingEnabled (each omitted when null).
+        /// All three are now persisted in the <c>agent_settings</c> table rather
+        /// than written back as environment variables, so no daemon restart is
+        /// required — the agent re-reads them on every turn.</summary>
         public async Task<AppSettingsMutationResponse> UpdateAppSettingsAsync(
-            string? terminalAccess, bool? webSearchEnabled)
+            string? terminalAccess, bool? webSearchEnabled, bool? usageRecordingEnabled = null)
         {
             using var req = BuildRequest(HttpMethod.Patch, "/api/app-settings");
             var body = new Dictionary<string, object?>();
-            if (terminalAccess != null)        body["terminalAccess"]   = terminalAccess;
-            if (webSearchEnabled.HasValue)     body["webSearchEnabled"] = webSearchEnabled.Value;
+            if (terminalAccess != null)          body["terminalAccess"]        = terminalAccess;
+            if (webSearchEnabled.HasValue)       body["webSearchEnabled"]      = webSearchEnabled.Value;
+            if (usageRecordingEnabled.HasValue)  body["usageRecordingEnabled"] = usageRecordingEnabled.Value;
             req.Content = JsonContent.Create(body);
             using var resp = await Http.SendAsync(req);
             await EnsureSuccessAsync(resp);
             return ParseAppSettingsMutation(await resp.Content.ReadAsStringAsync());
+        }
+
+        /// <summary>GET /api/usage?range=&amp;provider= — token counters for the
+        /// selected window. <paramref name="range"/> accepts the same tokens as
+        /// macOS ("7d" / "30d" / "90d" / "month" / "all"); <paramref name="provider"/>
+        /// of null or "all" omits the filter so every provider is aggregated.</summary>
+        public async Task<UsageMetricsResponse> FetchUsageMetricsAsync(
+            string range, string? provider = null)
+        {
+            string path = $"/api/usage?range={Uri.EscapeDataString(range)}";
+            if (!string.IsNullOrWhiteSpace(provider) && provider != "all")
+                path += $"&provider={Uri.EscapeDataString(provider)}";
+
+            using var req  = BuildRequest(HttpMethod.Get, path);
+            using var resp = await Http.SendAsync(req);
+            await EnsureSuccessAsync(resp);
+            return await resp.Content.ReadFromJsonAsync<UsageMetricsResponse>()
+                   ?? new UsageMetricsResponse();
         }
 
         /// <summary>POST /api/app-settings/browser-access — enable/disable
@@ -654,8 +790,30 @@ namespace OmniKey.Windows
                 BaseUrl = ReadString(root, "baseUrl"),
                 ActiveProvider = ReadString(root, "activeProvider"),
                 RestartScheduled = ReadNullableBool(root, "restartScheduled"),
-                Message = ReadString(root, "message")
+                Message = ReadString(root, "message"),
+                Model = ReadString(root, "model"),
+                ActiveModel = ReadString(root, "activeModel"),
+                ModelOptions = ReadModelOptions(root, "modelOptions")
             };
+        }
+
+        /// <summary>Reads a <c>modelOptions</c> array off a mutation response.
+        /// Returns null (rather than an empty list) when the key is absent so
+        /// callers can tell "server didn't say" from "server says none" and keep
+        /// the previously-loaded options instead of blanking the picker.</summary>
+        private static List<AgentModelOptionDto>? ReadModelOptions(JsonElement el, string name)
+        {
+            if (!el.TryGetProperty(name, out var arr) || arr.ValueKind != JsonValueKind.Array)
+                return null;
+
+            var options = new List<AgentModelOptionDto>();
+            foreach (var item in arr.EnumerateArray())
+            {
+                string id = ReadString(item, "id") ?? "";
+                if (id.Length == 0) continue;
+                options.Add(new AgentModelOptionDto { Id = id, Label = ReadString(item, "label") ?? id });
+            }
+            return options;
         }
 
         private static AppSettingsMutationResponse ParseAppSettingsMutation(string body)
@@ -667,6 +825,7 @@ namespace OmniKey.Windows
                 TerminalAccess = ReadString(root, "terminalAccess") ?? "limited",
                 WebSearchEnabled = ReadBool(root, "webSearchEnabled"),
                 BrowserAccessEnabled = ReadBool(root, "browserAccessEnabled"),
+                UsageRecordingEnabled = ReadBool(root, "usageRecordingEnabled"),
                 RestartScheduled = ReadNullableBool(root, "restartScheduled"),
                 Message = ReadString(root, "message")
             };

--- a/windows/ChatModel.cs
+++ b/windows/ChatModel.cs
@@ -367,18 +367,18 @@ namespace OmniKey.Windows
             get
             {
                 if (CanChangeSessionSetup)
-                    return DefaultTaskTemplate?.Heading ?? "No instruction";
+                    return DefaultTaskTemplate?.Heading ?? "No task instructions";
 
                 var locked = ActiveSession?.TaskInstructionHeading;
                 if (!string.IsNullOrEmpty(locked))
                     return locked!;
 
-                return "No instruction";
+                return "No task instructions";
             }
         }
 
         public bool HasDisplayedTaskInstruction =>
-            DisplayedTaskInstructionHeading != "No instruction";
+            DisplayedTaskInstructionHeading != "No task instructions";
 
 
         /// <summary>One-shot signal consumed by the sidebar: when set, the

--- a/windows/ChatModel.cs
+++ b/windows/ChatModel.cs
@@ -115,6 +115,168 @@ namespace OmniKey.Windows
         /// for the active subscription. Drives the sidebar group filter pills.</summary>
         public List<AgentGroupInfo> AvailableGroups { get; private set; } = new();
 
+        // ── Agent model selection ────────────────────────────────────
+        // Mirrors macOS ChatModel.activeAIProvider / activeAgentModel /
+        // activeAgentModelOptions. The model now lives in the agent_settings
+        // table (openai_model / anthropic_model / …), so changing it is a
+        // PATCH /api/providers/{provider}/model and takes effect on the next
+        // turn with no daemon restart.
+
+        /// <summary>Provider whose key is currently activated server-side.</summary>
+        public string ActiveAIProvider { get; private set; } = "openai";
+
+        /// <summary>Model id the agent will use for the next turn.</summary>
+        public string ActiveAgentModel { get; private set; } = "gpt-5.5";
+
+        /// <summary>Curated model list for <see cref="ActiveAIProvider"/>.</summary>
+        public List<AgentModelOptionDto> ActiveAgentModelOptions { get; private set; } = new();
+
+        /// <summary>True while a model change is in flight; the composer pill
+        /// disables itself so two PATCHes can't race.</summary>
+        public bool IsUpdatingAgentModel { get; private set; }
+
+        /// <summary>Friendly label for the active model — the server-supplied
+        /// label when the id is in the curated list, otherwise a prettified
+        /// form of the raw id (so custom models still read well).</summary>
+        public string ActiveAgentModelLabel
+        {
+            get
+            {
+                var match = ActiveAgentModelOptions
+                    .Find(o => string.Equals(o.Id, ActiveAgentModel, StringComparison.Ordinal));
+                return match?.Label ?? PrettyModelLabel(ActiveAgentModel);
+            }
+        }
+
+        /// <summary>Local fallback list used when the server returns no
+        /// <c>modelOptions</c> (older daemon). Kept byte-identical to
+        /// AGENT_MODEL_OPTIONS in api/src/agentSettingsStore.ts and to the
+        /// macOS fallbackAgentModelOptions(for:) switch.</summary>
+        private static List<AgentModelOptionDto> FallbackAgentModelOptions(string provider) => provider switch
+        {
+            "anthropic" => new()
+            {
+                new() { Id = "claude-opus-4-5",   Label = "Claude Opus 4.5" },
+                new() { Id = "claude-opus-4-7",   Label = "Claude Opus 4.7" },
+                new() { Id = "claude-opus-5",     Label = "Claude Opus 5.0" },
+                new() { Id = "claude-sonnet-4-5", Label = "Claude Sonnet 4.5" },
+                new() { Id = "claude-sonnet-4-6", Label = "Claude Sonnet 4.6" },
+                new() { Id = "claude-sonnet-5",   Label = "Claude Sonnet 5.0" },
+                new() { Id = "claude-fable-5",    Label = "Claude Fable 5.0" },
+            },
+            "gemini" => new()
+            {
+                new() { Id = "gemini-2.5-pro",   Label = "Gemini 2.5 Pro" },
+                new() { Id = "gemini-2.5-flash", Label = "Gemini 2.5 Flash" },
+            },
+            "nemotron" => new()
+            {
+                new() { Id = "nvidia/nemotron-3-ultra-550b-a55b", Label = "nvidia/nemotron-3-ultra-550b-a55b" },
+                new() { Id = "nvidia/nemotron-3-super-120b-a12b", Label = "nvidia/nemotron-3-super-120b-a12b" },
+                new() { Id = "nvidia/nemotron-3-nano-30b-a3b",    Label = "nvidia/nemotron-3-nano-30b-a3b" },
+            },
+            _ => new()
+            {
+                new() { Id = "gpt-5.6", Label = "GPT 5.6" },
+                new() { Id = "gpt-5.5", Label = "GPT 5.5" },
+                new() { Id = "gpt-5.1", Label = "GPT 5.1" },
+                new() { Id = "gpt-4.1", Label = "GPT 4.1" },
+            },
+        };
+
+        private static string PrettyModelLabel(string model)
+        {
+            if (string.IsNullOrEmpty(model)) return "Model";
+            if (model.StartsWith("gpt-", StringComparison.Ordinal))
+                return model.Replace("gpt-", "GPT ", StringComparison.Ordinal);
+            if (model.StartsWith("nvidia/", StringComparison.Ordinal)) return model;
+            if (model.Contains("opus",   StringComparison.Ordinal)) return "Opus";
+            if (model.Contains("fable",  StringComparison.Ordinal)) return "Fable";
+            if (model.Contains("sonnet", StringComparison.Ordinal)) return "Sonnet";
+            return model;
+        }
+
+        /// <summary>Load the active provider, its persisted model and the
+        /// curated option list. Fire-and-forget; failures leave the previous
+        /// selection intact so the composer never loses its pill.</summary>
+        public void FetchAgentModelOptions() => _ = FetchAgentModelOptionsAsync();
+
+        private async Task FetchAgentModelOptionsAsync()
+        {
+            try
+            {
+                var response = await _apiClient.FetchAIProvidersAsync();
+                RunOnUi(() =>
+                {
+                    string provider = string.IsNullOrEmpty(response.ActiveProvider)
+                        ? ActiveAIProvider
+                        : response.ActiveProvider;
+                    var options = response.ModelOptions.Count > 0
+                        ? response.ModelOptions
+                        : FallbackAgentModelOptions(provider);
+
+                    ActiveAIProvider = provider;
+                    ActiveAgentModelOptions = options;
+                    ActiveAgentModel = !string.IsNullOrEmpty(response.ActiveModel)
+                        ? response.ActiveModel!
+                        : (options.Count > 0 ? options[0].Id : ActiveAgentModel);
+                    NotifyStateChanged();
+                });
+            }
+            catch
+            {
+                // Non-fatal: the pill keeps whatever it last showed. A model
+                // list is a convenience, not a precondition for chatting.
+            }
+        }
+
+        /// <summary>Persist a new model for the active provider. Optimistically
+        /// updates the pill, then rolls back and surfaces an error if the PATCH
+        /// fails — mirrors macOS setAgentModel(_:).</summary>
+        public void SetAgentModel(string modelId)
+        {
+            if (string.IsNullOrWhiteSpace(modelId)) return;
+            modelId = modelId.Trim();
+            if (string.Equals(modelId, ActiveAgentModel, StringComparison.Ordinal)) return;
+            if (IsUpdatingAgentModel) return;
+            _ = SetAgentModelAsync(modelId);
+        }
+
+        private async Task SetAgentModelAsync(string modelId)
+        {
+            string provider = ActiveAIProvider;
+            string previousModel = ActiveAgentModel;
+
+            ActiveAgentModel = modelId;
+            IsUpdatingAgentModel = true;
+            NotifyStateChanged();
+
+            try
+            {
+                var response = await _apiClient.UpdateProviderModelAsync(provider, modelId);
+                RunOnUi(() =>
+                {
+                    IsUpdatingAgentModel = false;
+                    ActiveAgentModel = response.ActiveModel ?? response.Model ?? modelId;
+                    // Null means "server didn't report options" — keep the current
+                    // list rather than emptying the picker.
+                    if (response.ModelOptions is { Count: > 0 } options)
+                        ActiveAgentModelOptions = options;
+                    NotifyStateChanged();
+                });
+            }
+            catch (Exception ex)
+            {
+                RunOnUi(() =>
+                {
+                    IsUpdatingAgentModel = false;
+                    ActiveAgentModel = previousModel;
+                    LastErrorMessage = $"Failed to change model: {ex.Message}";
+                    NotifyStateChanged();
+                });
+            }
+        }
+
         /// <summary>The project group the user picked in the composer.
         /// When set, its <c>GroupName</c> is sent with the next chat turn
         /// so the backend can stamp the new session with that group.

--- a/windows/ViewModels/AgentSessionRows.cs
+++ b/windows/ViewModels/AgentSessionRows.cs
@@ -38,13 +38,11 @@ namespace OmniKey.Windows.ViewModels
         [ObservableProperty] private string text = "";
         [ObservableProperty] private bool isExpanded;
 
-        /// <summary>
-        /// First non-empty line of <see cref="Text"/>, trimmed to ~80
-        /// characters. Shown next to the label when the row is
-        /// collapsed so the user can scan the timeline without
-        /// expanding every step.
-        /// </summary>
-        public string Summary => BuildSummary(Text);
+        /// <summary>Concise preview shown when the row is collapsed.</summary>
+        public string Summary => AgentTimelineSummarizer.CollapsedSummary(Kind, Text);
+
+        /// <summary>Expanded detail stays summarized so raw tool payloads do not dominate the UI.</summary>
+        public string ExpandedSummary => AgentTimelineSummarizer.ExpandedSummary(Kind, Text);
 
         public AgentTimelineRow(TimelineKind kind, string text)
         {
@@ -63,7 +61,11 @@ namespace OmniKey.Windows.ViewModels
         [RelayCommand]
         private void Toggle() => IsExpanded = !IsExpanded;
 
-        partial void OnTextChanged(string value) => OnPropertyChanged(nameof(Summary));
+        partial void OnTextChanged(string value)
+        {
+            OnPropertyChanged(nameof(Summary));
+            OnPropertyChanged(nameof(ExpandedSummary));
+        }
 
         private static Brush ResolveBrush(string key, Brush fallback)
         {
@@ -71,18 +73,6 @@ namespace OmniKey.Windows.ViewModels
             return fallback;
         }
 
-        private static string BuildSummary(string text)
-        {
-            if (string.IsNullOrWhiteSpace(text)) return "";
-            // Skip leading blank lines, take the first content line.
-            foreach (var raw in text.Split('\n'))
-            {
-                var trimmed = raw.Trim();
-                if (trimmed.Length == 0) continue;
-                return trimmed.Length > 80 ? trimmed[..80] + "…" : trimmed;
-            }
-            return "";
-        }
     }
 
     /// <summary>

--- a/windows/ViewModels/AgentTimelineSummarizer.cs
+++ b/windows/ViewModels/AgentTimelineSummarizer.cs
@@ -1,0 +1,318 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+
+namespace OmniKey.Windows.ViewModels
+{
+    /// <summary>
+    /// Concise display text for agent timeline/tool blocks. Mirrors the macOS
+    /// AgentTimelineSummarizer so Windows shows readable step summaries instead
+    /// of raw shell, MCP, web, or terminal payloads.
+    /// </summary>
+    internal static class AgentTimelineSummarizer
+    {
+        private enum DisplayKind
+        {
+            AgentReasoning,
+            ShellCommand,
+            TerminalOutput,
+            WebCall,
+            McpCall,
+            ImageRendering,
+            FinalAnswer,
+        }
+
+        private readonly record struct Summary(string Collapsed, string Expanded);
+
+        public static string CollapsedSummary(ChatBlockKind kind, string text) =>
+            Summarize(DisplayKindFor(kind), text).Collapsed;
+
+        public static string ExpandedSummary(ChatBlockKind kind, string text) =>
+            Summarize(DisplayKindFor(kind), text).Expanded;
+
+        public static string CollapsedSummary(TimelineKind kind, string text) =>
+            Summarize(DisplayKindFor(kind), text).Collapsed;
+
+        public static string ExpandedSummary(TimelineKind kind, string text) =>
+            Summarize(DisplayKindFor(kind), text).Expanded;
+
+        private static DisplayKind DisplayKindFor(ChatBlockKind kind) => kind switch
+        {
+            ChatBlockKind.AgentReasoning => DisplayKind.AgentReasoning,
+            ChatBlockKind.ShellCommand => DisplayKind.ShellCommand,
+            ChatBlockKind.TerminalOutput => DisplayKind.TerminalOutput,
+            ChatBlockKind.WebCall => DisplayKind.WebCall,
+            ChatBlockKind.McpCall => DisplayKind.McpCall,
+            ChatBlockKind.ImageRendering => DisplayKind.ImageRendering,
+            ChatBlockKind.FinalAnswer => DisplayKind.FinalAnswer,
+            _ => DisplayKind.AgentReasoning,
+        };
+
+        private static DisplayKind DisplayKindFor(TimelineKind kind) => kind switch
+        {
+            TimelineKind.Web => DisplayKind.WebCall,
+            TimelineKind.Mcp => DisplayKind.McpCall,
+            TimelineKind.Terminal => DisplayKind.TerminalOutput,
+            TimelineKind.Reasoning => DisplayKind.AgentReasoning,
+            _ => DisplayKind.AgentReasoning,
+        };
+
+        private static Summary Summarize(DisplayKind kind, string text) => kind switch
+        {
+            DisplayKind.ShellCommand => SummarizeShellCommand(text),
+            DisplayKind.TerminalOutput => SummarizeTerminalOutput(text),
+            DisplayKind.McpCall => SummarizeMcp(text),
+            DisplayKind.WebCall => SummarizeWebCall(text),
+            DisplayKind.ImageRendering => SummarizeGeneric(text, "Image task updated"),
+            _ => SummarizeGeneric(text, ""),
+        };
+
+        private static Summary SummarizeShellCommand(string text)
+        {
+            var lines = MeaningfulLines(text)
+                .Where(line => !IsShellBoilerplate(line))
+                .Take(4)
+                .Select(CommandDescription)
+                .ToList();
+
+            if (lines.Count == 0)
+            {
+                return new Summary(
+                    "Running a shell script",
+                    "Running a shell script. No concise command preview is available.");
+            }
+
+            string collapsed = Truncate(lines[0], 160);
+            string bullets = string.Join("\n", lines.Select(line => "- " + line));
+            int totalLines = MeaningfulLines(text).Count;
+            string suffix = totalLines > lines.Count
+                ? $"\n- Plus {totalLines - lines.Count} additional script line(s)."
+                : "";
+            return new Summary(collapsed, $"Running shell script:\n{bullets}{suffix}");
+        }
+
+        private static Summary SummarizeTerminalOutput(string text)
+        {
+            var parts = TerminalParts(text);
+            string body = parts.Body.Trim();
+            var lines = MeaningfulLines(body);
+            string status = parts.IsError ? "Command failed" : "Command finished";
+            string statusText = parts.StatusLabel is { Length: > 0 }
+                ? $"{status} ({parts.StatusLabel})"
+                : status;
+
+            if (body.Length == 0)
+            {
+                return new Summary(
+                    $"{statusText} with no output",
+                    $"{statusText}.\n- Output: no text was produced.");
+            }
+
+            string preview = PreviewText(lines, body);
+            string collapsed = Truncate($"{statusText}: {preview}", 180);
+            string expanded = string.Join("\n", new[]
+            {
+                $"{statusText}.",
+                $"- Output size: {lines.Count} line{(lines.Count == 1 ? "" : "s")}, {body.Length} characters.",
+                $"- Key output: {preview}",
+            });
+            return new Summary(collapsed, expanded);
+        }
+
+        private static Summary SummarizeMcp(string text)
+        {
+            string trimmed = text.Trim();
+            string? toolName = ExtractToolName(trimmed, "Calling MCP tool:", "Tool:");
+            string body = ResultBody(trimmed);
+
+            if (!string.IsNullOrWhiteSpace(toolName) && string.IsNullOrWhiteSpace(body))
+            {
+                string label = $"Calling MCP tool {toolName}";
+                return new Summary(label, label);
+            }
+
+            string target = !string.IsNullOrWhiteSpace(toolName) ? $"MCP tool {toolName}" : "MCP tool";
+            var result = ResultSummary(string.IsNullOrWhiteSpace(body) ? trimmed : body);
+            return new Summary(
+                Truncate($"{target}: {result.Collapsed}", 180),
+                $"{target} returned a result.\n{result.Expanded}");
+        }
+
+        private static Summary SummarizeWebCall(string text)
+        {
+            string trimmed = text.Trim();
+            string? toolName = ExtractToolName(trimmed, "Tool:");
+            string body = ResultBody(trimmed);
+
+            if (!string.IsNullOrWhiteSpace(toolName))
+            {
+                var result = ResultSummary(body);
+                return new Summary(
+                    Truncate($"{toolName}: {result.Collapsed}", 180),
+                    $"Web tool {toolName} returned a result.\n{result.Expanded}");
+            }
+
+            return SummarizeGeneric(trimmed, "Web activity updated");
+        }
+
+        private static Summary SummarizeGeneric(string text, string fallback)
+        {
+            string trimmed = text.Trim();
+            if (trimmed.Length == 0) return new Summary(fallback, fallback);
+            string preview = PreviewText(MeaningfulLines(trimmed), trimmed);
+            return new Summary(Truncate(preview, 180), Truncate(preview, 600));
+        }
+
+        private static Summary ResultSummary(string text)
+        {
+            string trimmed = text.Trim();
+            if (trimmed.Length == 0)
+                return new Summary("No result text", "- Result: no text was returned.");
+
+            if (DescribeJson(trimmed) is { } jsonDescription)
+            {
+                string preview = PreviewText(MeaningfulLines(trimmed), trimmed);
+                return new Summary(
+                    jsonDescription,
+                    $"- Result shape: {jsonDescription}.\n- Preview: {preview}");
+            }
+
+            var lines = MeaningfulLines(trimmed);
+            string bodyPreview = PreviewText(lines, trimmed);
+            return new Summary(
+                bodyPreview,
+                $"- Result size: {lines.Count} line{(lines.Count == 1 ? "" : "s")}, {trimmed.Length} characters.\n- Preview: {bodyPreview}");
+        }
+
+        private static (string? StatusLabel, bool IsError, string Body) TerminalParts(string text)
+        {
+            string trimmed = text.Trim();
+            var lines = trimmed.Split('\n').ToList();
+            string first = lines.FirstOrDefault()?.Trim() ?? "";
+
+            if (first.StartsWith("[terminal ", StringComparison.OrdinalIgnoreCase))
+            {
+                lines.RemoveAt(0);
+                string status = first
+                    .Replace("[terminal ", "", StringComparison.OrdinalIgnoreCase)
+                    .Replace("]", "")
+                    .Trim();
+                return (status, status.Contains("error", StringComparison.OrdinalIgnoreCase), string.Join("\n", lines));
+            }
+
+            if (string.Equals(first, "command error", StringComparison.OrdinalIgnoreCase))
+            {
+                lines.RemoveAt(0);
+                return ("error", true, string.Join("\n", lines));
+            }
+
+            return (null, false, trimmed);
+        }
+
+        private static string ResultBody(string text)
+        {
+            var parts = text.Split(new[] { "\n\n" }, StringSplitOptions.None);
+            if (parts.Length <= 1) return "";
+            return string.Join("\n\n", parts.Skip(1)).Trim();
+        }
+
+        private static string? ExtractToolName(string text, params string[] prefixes)
+        {
+            string firstLine = text.Split('\n').FirstOrDefault()?.Trim() ?? "";
+            foreach (string prefix in prefixes)
+            {
+                if (!firstLine.StartsWith(prefix, StringComparison.Ordinal)) continue;
+                string name = firstLine[prefix.Length..].Trim();
+                return name.Length == 0 ? null : name;
+            }
+            return null;
+        }
+
+        private static List<string> MeaningfulLines(string text) =>
+            text.Split('\n')
+                .Select(NormalizeInlineWhitespace)
+                .Where(line =>
+                    line.Length > 0 &&
+                    !string.Equals(line, "TERMINAL OUTPUT:", StringComparison.Ordinal) &&
+                    !string.Equals(line, "COMMAND ERROR:", StringComparison.Ordinal))
+                .ToList();
+
+        private static bool IsShellBoilerplate(string line)
+        {
+            string lower = line.ToLowerInvariant();
+            return lower is "set -e" or "set -eu" or "set -euo pipefail" or "set -o pipefail"
+                or "then" or "do" or "done" or "fi"
+                || lower.StartsWith("#", StringComparison.Ordinal);
+        }
+
+        private static string CommandDescription(string line)
+        {
+            string trimmed = line.Trim();
+            string lower = trimmed.ToLowerInvariant();
+
+            if (lower.StartsWith("cd ", StringComparison.Ordinal)) return $"Change directory to {Truncate(trimmed[3..], 80)}";
+            if (lower.StartsWith("git ", StringComparison.Ordinal)) return $"Run git {Truncate(trimmed[4..], 100)}";
+            if (lower.StartsWith("rg ", StringComparison.Ordinal)) return "Search files with ripgrep";
+            if (lower.StartsWith("grep ", StringComparison.Ordinal)) return "Search text with grep";
+            if (lower.StartsWith("find ", StringComparison.Ordinal)) return "Find matching files";
+            if (lower.StartsWith("sed ", StringComparison.Ordinal)) return "Read a selected range of a file";
+            if (lower.StartsWith("cat ", StringComparison.Ordinal)) return "Read file contents";
+            if (lower.StartsWith("sqlite3 ", StringComparison.Ordinal)) return "Query the local SQLite database";
+            if (lower.StartsWith("npm ", StringComparison.Ordinal) ||
+                lower.StartsWith("yarn ", StringComparison.Ordinal) ||
+                lower.StartsWith("pnpm ", StringComparison.Ordinal))
+                return $"Run package script: {Truncate(trimmed, 120)}";
+            if (lower.StartsWith("dotnet ", StringComparison.Ordinal) ||
+                lower.StartsWith("msbuild ", StringComparison.Ordinal))
+                return $"Run Windows build command: {Truncate(trimmed, 120)}";
+            if (lower.StartsWith("python ", StringComparison.Ordinal) ||
+                lower.StartsWith("python3 ", StringComparison.Ordinal) ||
+                lower.StartsWith("py ", StringComparison.Ordinal))
+                return "Run Python helper script";
+            if (lower.StartsWith("node ", StringComparison.Ordinal)) return "Run Node.js helper script";
+
+            return Truncate(trimmed, 140);
+        }
+
+        private static string PreviewText(IReadOnlyList<string> lines, string fallback)
+        {
+            var candidates = lines.Count == 0 ? MeaningfulLines(fallback) : lines;
+            string preview = string.Join("; ", candidates.Take(3).Select(line => Truncate(line, 120)));
+            if (preview.Length > 0) return Truncate(preview, 260);
+            return Truncate(NormalizeInlineWhitespace(fallback), 260);
+        }
+
+        private static string? DescribeJson(string text)
+        {
+            string trimmed = text.Trim();
+            if (!trimmed.StartsWith("{", StringComparison.Ordinal) &&
+                !trimmed.StartsWith("[", StringComparison.Ordinal))
+                return null;
+
+            try
+            {
+                using var doc = JsonDocument.Parse(trimmed);
+                return doc.RootElement.ValueKind switch
+                {
+                    JsonValueKind.Object => $"JSON object with {doc.RootElement.EnumerateObject().Count()} field{(doc.RootElement.EnumerateObject().Count() == 1 ? "" : "s")}",
+                    JsonValueKind.Array => $"JSON array with {doc.RootElement.GetArrayLength()} item{(doc.RootElement.GetArrayLength() == 1 ? "" : "s")}",
+                    _ => "JSON value",
+                };
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static string NormalizeInlineWhitespace(string text) =>
+            string.Join(" ", text.Trim().Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries));
+
+        private static string Truncate(string text, int max)
+        {
+            if (text.Length <= max) return text;
+            return text[..max].Trim() + "...";
+        }
+    }
+}

--- a/windows/ViewModels/ChatViewModel.cs
+++ b/windows/ViewModels/ChatViewModel.cs
@@ -22,6 +22,7 @@ namespace OmniKey.Windows.ViewModels
         private bool _suppressSelectionFeedback;
         private bool _suppressDefaultTemplateFeedback;
         private bool _suppressSelectedGroupFeedback;
+        private bool _suppressAgentModelFeedback;
 
         public ObservableCollection<AgentSessionInfo> Sessions { get; } = new();
         public ObservableCollection<ChatMessageRow> Messages { get; } = new();
@@ -39,6 +40,12 @@ namespace OmniKey.Windows.ViewModels
         /// fetches groups. Mirrors the task-template pattern next to it.</summary>
         public ObservableCollection<AgentGroupInfo> AvailableProjectGroups { get; } =
             new() { NoProjectSentinel };
+
+        /// <summary>Model options offered by the composer's model pill for the
+        /// currently activated provider. Populated from
+        /// <see cref="ChatModel.ActiveAgentModelOptions"/> (server-curated, with
+        /// a local fallback) so the picker mirrors the macOS AgentModelMenu.</summary>
+        public ObservableCollection<AgentModelOptionDto> AvailableAgentModels { get; } = new();
 
         // Seed with the sentinel so the ComboBox can resolve its SelectedValue
         // (which defaults to "" for "no template active") on the very first
@@ -140,6 +147,47 @@ namespace OmniKey.Windows.ViewModels
                 };
             }
         }
+
+        // ── Agent model pill ───────────────────────────────────────
+
+        /// <summary>Id-based two-way binding for the composer's model ComboBox.
+        /// Bound by id (not reference) for the same reason as the template and
+        /// project pickers: the model rebuilds its option DTOs on every refresh,
+        /// which would orphan a reference-based SelectedItem and fire a spurious
+        /// change back through the setter.</summary>
+        public string? SelectedAgentModelId
+        {
+            get => _model.ActiveAgentModel;
+            set
+            {
+                if (_suppressAgentModelFeedback) return;
+                if (string.IsNullOrWhiteSpace(value)) return;
+                if (string.Equals(_model.ActiveAgentModel, value, StringComparison.Ordinal)) return;
+                _model.SetAgentModel(value);
+            }
+        }
+
+        /// <summary>Friendly label shown on the pill when it is disabled (a turn
+        /// is running or a change is in flight).</summary>
+        public string ActiveAgentModelLabel => _model.ActiveAgentModelLabel;
+
+        /// <summary>The provider the model list belongs to — used in the pill's
+        /// tooltip so users know which vendor's ids are valid.</summary>
+        public string ActiveAIProvider => _model.ActiveAIProvider;
+
+        public bool IsUpdatingAgentModel => _model.IsUpdatingAgentModel;
+
+        /// <summary>The picker is hidden entirely when there is nothing to pick
+        /// (no provider activated yet / offline first load).</summary>
+        public bool HasAgentModelOptions => AvailableAgentModels.Count > 0;
+
+        /// <summary>Model is locked mid-turn so the request and the recorded
+        /// usage row can't disagree about which model served it.</summary>
+        public bool CanChangeAgentModel => !_model.IsRunning && !_model.IsUpdatingAgentModel;
+
+        public string AgentModelTooltip => _model.IsRunning
+            ? "Model is locked while a turn is running"
+            : $"Choose the {_model.ActiveAIProvider} model for the next turn";
 
         public string InputText
         {
@@ -281,6 +329,9 @@ namespace OmniKey.Windows.ViewModels
         {
             _model.RefreshSessions();
             _model.FetchDefaultTaskTemplate();
+            // Populate the composer's model pill. Mirrors macOS ChatView.onAppear
+            // calling fetchAgentModelOptions().
+            _model.FetchAgentModelOptions();
         }
 
         [RelayCommand]
@@ -418,6 +469,20 @@ namespace OmniKey.Windows.ViewModels
                 _suppressSelectedGroupFeedback = false;
             }
 
+            // Agent models — same suppression window: rebuilding the items
+            // transiently leaves the ComboBox with no match, and its auto-fired
+            // SelectionChanged would otherwise PATCH a model the user never picked.
+            _suppressAgentModelFeedback = true;
+            try
+            {
+                SyncAgentModels(_model.ActiveAgentModelOptions);
+                OnPropertyChanged(nameof(SelectedAgentModelId));
+            }
+            finally
+            {
+                _suppressAgentModelFeedback = false;
+            }
+
             // Scalar properties
             ActiveSessionTitle = _model.ActiveSessionTitle;
             IsRunning = _model.IsRunning;
@@ -440,6 +505,34 @@ namespace OmniKey.Windows.ViewModels
             OnPropertyChanged(nameof(IsSessionSetupLocked));
             OnPropertyChanged(nameof(DisplayedTaskInstructionHeading));
             OnPropertyChanged(nameof(TaskInstructionTooltip));
+            OnPropertyChanged(nameof(ActiveAgentModelLabel));
+            OnPropertyChanged(nameof(ActiveAIProvider));
+            OnPropertyChanged(nameof(IsUpdatingAgentModel));
+            OnPropertyChanged(nameof(HasAgentModelOptions));
+            OnPropertyChanged(nameof(CanChangeAgentModel));
+            OnPropertyChanged(nameof(AgentModelTooltip));
+        }
+
+        /// <summary>Diff the model-option list by id so a realized ComboBox keeps
+        /// its item containers (and its open dropdown) across refresh ticks.
+        /// Only rebuilds when the ids actually differ.</summary>
+        private void SyncAgentModels(IList<AgentModelOptionDto> source)
+        {
+            bool sameIds = AvailableAgentModels.Count == source.Count;
+            if (sameIds)
+            {
+                for (int i = 0; i < source.Count; i++)
+                {
+                    if (string.Equals(AvailableAgentModels[i].Id, source[i].Id, StringComparison.Ordinal))
+                        continue;
+                    sameIds = false;
+                    break;
+                }
+            }
+            if (sameIds) return;
+
+            AvailableAgentModels.Clear();
+            foreach (var option in source) AvailableAgentModels.Add(option);
         }
 
         private static void ReplaceCollection<T>(ObservableCollection<T> target, IList<T> source)

--- a/windows/ViewModels/ChatViewModel.cs
+++ b/windows/ViewModels/ChatViewModel.cs
@@ -328,6 +328,7 @@ namespace OmniKey.Windows.ViewModels
         private void Load()
         {
             _model.RefreshSessions();
+            _model.FetchGroups();
             _model.FetchDefaultTaskTemplate();
             // Populate the composer's model pill. Mirrors macOS ChatView.onAppear
             // calling fetchAgentModelOptions().
@@ -961,20 +962,11 @@ namespace OmniKey.Windows.ViewModels
             _ => "Circle24",
         };
 
-        /// <summary>Compact preview (first non-empty line, capped at 120 chars).</summary>
-        public string Summary
-        {
-            get
-            {
-                var raw = Text?.Trim() ?? string.Empty;
-                if (raw.Length == 0) return string.Empty;
-                var firstLine = raw.Split('\n', StringSplitOptions.RemoveEmptyEntries)
-                                   .FirstOrDefault(line => !string.IsNullOrWhiteSpace(line)) ?? string.Empty;
-                var s = firstLine.Trim();
-                if (s.Length == 0) s = raw;
-                return s.Length > 120 ? s[..120] + "…" : s;
-            }
-        }
+        /// <summary>Concise preview for raw tool/script blocks.</summary>
+        public string Summary => AgentTimelineSummarizer.CollapsedSummary(Kind, Text);
+
+        /// <summary>Expanded detail still shows a readable summary, not raw payload text.</summary>
+        public string ExpandedSummary => AgentTimelineSummarizer.ExpandedSummary(Kind, Text);
 
         public Brush AccentBrush => Kind switch
         {

--- a/windows/ViewModels/SettingsViewModel.cs
+++ b/windows/ViewModels/SettingsViewModel.cs
@@ -15,6 +15,7 @@ namespace OmniKey.Windows.ViewModels
     {
         Providers,
         AgentAccess,
+        Usage,
         Updates,
         Manual,
     }
@@ -150,11 +151,20 @@ namespace OmniKey.Windows.ViewModels
         [ObservableProperty] private string terminalAccess = "limited";
         [ObservableProperty] private bool webSearchEnabled;
         [ObservableProperty] private bool browserAccessEnabled;
+        [ObservableProperty] private bool usageRecordingEnabled;
         [ObservableProperty] private string browserAccessSummary = "Not loaded";
 
         [ObservableProperty] private string pendingTerminalAccess = "limited";
         [ObservableProperty] private bool pendingWebSearchEnabled;
         [ObservableProperty] private bool pendingBrowserAccessEnabled;
+        [ObservableProperty] private bool pendingUsageRecordingEnabled;
+
+        /// <summary>Where the daemon loaded these settings from. The backend
+        /// now serves them out of the <c>agent_settings</c> table instead of
+        /// environment variables, so edits apply on the next agent turn with no
+        /// restart. Shown as a footnote on the Agent Access pane.</summary>
+        [ObservableProperty] private string settingsSourceSummary =
+            "Settings are stored in the agent database and apply on the next turn.";
 
         // Status / busy --------------------------------------------------------
         [ObservableProperty] private bool isBusy;
@@ -194,13 +204,15 @@ namespace OmniKey.Windows.ViewModels
         public bool AgentAccessDirty =>
             PendingTerminalAccess != TerminalAccess
             || PendingWebSearchEnabled != WebSearchEnabled
-            || PendingBrowserAccessEnabled != BrowserAccessEnabled;
+            || PendingBrowserAccessEnabled != BrowserAccessEnabled
+            || PendingUsageRecordingEnabled != UsageRecordingEnabled;
 
         public bool CanSaveAgentAccess => !IsBusy && AgentAccessDirty;
 
         // ---- Sidebar selection helpers (bool bindings for sidebar buttons) ---
         public bool IsProvidersSelected => SelectedSection == SettingsSection.Providers;
         public bool IsAgentAccessSelected => SelectedSection == SettingsSection.AgentAccess;
+        public bool IsUsageSelected => SelectedSection == SettingsSection.Usage;
         public bool IsUpdatesSelected => SelectedSection == SettingsSection.Updates;
         public bool IsManualSelected => SelectedSection == SettingsSection.Manual;
 
@@ -223,6 +235,7 @@ namespace OmniKey.Windows.ViewModels
             ProvidersMode = ProvidersMode.List;
             OnPropertyChanged(nameof(IsProvidersSelected));
             OnPropertyChanged(nameof(IsAgentAccessSelected));
+            OnPropertyChanged(nameof(IsUsageSelected));
             OnPropertyChanged(nameof(IsUpdatesSelected));
             OnPropertyChanged(nameof(IsManualSelected));
             OnPropertyChanged(nameof(IsProvidersList));
@@ -267,9 +280,11 @@ namespace OmniKey.Windows.ViewModels
         partial void OnTerminalAccessChanged(string value) => RefreshAgentAccessDirty();
         partial void OnWebSearchEnabledChanged(bool value) => RefreshAgentAccessDirty();
         partial void OnBrowserAccessEnabledChanged(bool value) => RefreshAgentAccessDirty();
+        partial void OnUsageRecordingEnabledChanged(bool value) => RefreshAgentAccessDirty();
         partial void OnPendingTerminalAccessChanged(string value) => RefreshAgentAccessDirty();
         partial void OnPendingWebSearchEnabledChanged(bool value) => RefreshAgentAccessDirty();
         partial void OnPendingBrowserAccessEnabledChanged(bool value) => RefreshAgentAccessDirty();
+        partial void OnPendingUsageRecordingEnabledChanged(bool value) => RefreshAgentAccessDirty();
 
         private void RefreshAgentAccessDirty()
         {
@@ -321,12 +336,19 @@ namespace OmniKey.Windows.ViewModels
                 TerminalAccess = settings.TerminalAccess;
                 WebSearchEnabled = settings.WebSearchEnabled;
                 BrowserAccessEnabled = settings.BrowserAccessEnabled;
+                UsageRecordingEnabled = settings.UsageRecordingEnabled;
                 // Reset the pending values to whatever's persisted so the
                 // Save button only lights up after the user actually changes
                 // something.
                 PendingTerminalAccess = TerminalAccess;
                 PendingWebSearchEnabled = WebSearchEnabled;
                 PendingBrowserAccessEnabled = BrowserAccessEnabled;
+                PendingUsageRecordingEnabled = UsageRecordingEnabled;
+                // The backend reports "database" now that agent_settings backs
+                // these values; older daemons omit the field entirely.
+                SettingsSourceSummary = string.Equals(settings.Source, "database", StringComparison.OrdinalIgnoreCase)
+                    ? "Stored in the agent database — changes apply on the next agent turn, no restart needed."
+                    : "Stored by the agent daemon — update the daemon to get database-backed settings.";
                 BrowserAccessSummary = settings.BrowserAccessEnabled
                     ? $"Configured: {settings.BrowserDebugBrowserName ?? "browser"}" + (settings.BrowserDebugPort is int port ? $" • port {port}" : string.Empty)
                     : "Disabled";
@@ -393,11 +415,17 @@ namespace OmniKey.Windows.ViewModels
             {
                 string? termArg = PendingTerminalAccess != TerminalAccess ? PendingTerminalAccess : null;
                 bool? webArg = PendingWebSearchEnabled != WebSearchEnabled ? PendingWebSearchEnabled : (bool?)null;
+                bool? usageArg = PendingUsageRecordingEnabled != UsageRecordingEnabled
+                    ? PendingUsageRecordingEnabled
+                    : (bool?)null;
 
-                if (termArg is not null || webArg is not null)
+                if (termArg is not null || webArg is not null || usageArg is not null)
                 {
-                    var result = await _api.UpdateAppSettingsAsync(termArg, webArg);
-                    SetStatus(result.Message ?? "Agent access updated. Restart scheduled.", StatusKind.Positive);
+                    // Single PATCH covers all three: they all live in the
+                    // agent_settings row, and the agent re-reads them per turn,
+                    // so there's no restart to schedule any more.
+                    var result = await _api.UpdateAppSettingsAsync(termArg, webArg, usageArg);
+                    SetStatus(result.Message ?? "Agent access updated.", StatusKind.Positive);
                 }
 
                 bool launchingBrowserWizard = false;

--- a/windows/ViewModels/UsageViewModel.cs
+++ b/windows/ViewModels/UsageViewModel.cs
@@ -1,0 +1,400 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Media;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace OmniKey.Windows.ViewModels
+{
+    /// <summary>One entry in the range selector. Mirrors the macOS
+    /// <c>UsageRangeOption</c> enum (7d / 30d / month / 90d / all) so both
+    /// clients ask the backend for identical windows.</summary>
+    internal sealed class UsageRangeOption
+    {
+        public string Key { get; init; } = "30d";
+        public string Label { get; init; } = "30d";
+    }
+
+    /// <summary>One entry in the provider filter. Keys must match the
+    /// server-side provider identifiers (see <c>AIProviderDTO</c>) so filtering
+    /// works even before any calls have been recorded for a provider. Keep in
+    /// sync with <c>usageSupportedProviders</c> in macOS UsageView.swift.</summary>
+    internal sealed class UsageProviderOption
+    {
+        public string Key { get; init; } = "all";
+        public string Label { get; init; } = "All Providers";
+    }
+
+    /// <summary>A single "Tokens by model" meter row. Percentages and the
+    /// display strings are pre-computed here rather than in converters so the
+    /// XAML stays declarative and we avoid a converter per formatting rule.</summary>
+    internal sealed class UsageMeterRow
+    {
+        public string Label { get; init; } = "";
+        public string TokensDisplay { get; init; } = "";
+        public string DetailDisplay { get; init; } = "";
+
+        /// <summary>0-100, relative to the largest bucket in the list, so the
+        /// widest meter always fills the row.</summary>
+        public double Percent { get; init; }
+
+        public Brush Accent { get; init; } = Brushes.Gray;
+    }
+
+    /// <summary>A single day column in the "Daily Token Split" chart. Heights
+    /// are DIP values computed against <see cref="UsageViewModel.TrendChartHeight"/>
+    /// so the XAML can stack two plain rectangles without a layout converter.</summary>
+    internal sealed class UsageTrendBar
+    {
+        public string Label { get; init; } = "";
+        public double PromptHeight { get; init; }
+        public double CompletionHeight { get; init; }
+        public string Tooltip { get; init; } = "";
+    }
+
+    /// <summary>A row in the "Recent Sessions" list.</summary>
+    internal sealed class UsageSessionRow
+    {
+        public string Title { get; init; } = "";
+        public string TokensDisplay { get; init; } = "";
+        public string DetailDisplay { get; init; } = "";
+    }
+
+    /// <summary>
+    /// Backs the Usage page: token counters for a selected range and provider,
+    /// read from <c>GET /api/usage</c>. Mirrors macOS <c>UsageView</c> — cost
+    /// figures were deliberately dropped server-side because provider pricing
+    /// estimates can't be reconciled with invoices, so this reports only the
+    /// token metrics we can state accurately.
+    /// </summary>
+    internal partial class UsageViewModel : ObservableObject
+    {
+        /// <summary>Total height of the daily trend chart in DIP. Bars are
+        /// scaled against this so the tallest day fills the plot area.</summary>
+        public const double TrendChartHeight = 110d;
+
+        private readonly ApiClient _api = new();
+
+        /// <summary>Cancels an in-flight refresh when the user changes the range
+        /// or provider again before the previous request lands, so a slow earlier
+        /// response can't overwrite the newer selection.</summary>
+        private CancellationTokenSource? _inflight;
+
+        public IReadOnlyList<UsageRangeOption> RangeOptions { get; } = new[]
+        {
+            new UsageRangeOption { Key = "7d",    Label = "7 days" },
+            new UsageRangeOption { Key = "30d",   Label = "30 days" },
+            new UsageRangeOption { Key = "month", Label = "This month" },
+            new UsageRangeOption { Key = "90d",   Label = "90 days" },
+            new UsageRangeOption { Key = "all",   Label = "All time" },
+        };
+
+        public IReadOnlyList<UsageProviderOption> ProviderOptions { get; } = new[]
+        {
+            new UsageProviderOption { Key = "all",       Label = "All Providers" },
+            new UsageProviderOption { Key = "openai",    Label = "OpenAI" },
+            new UsageProviderOption { Key = "anthropic", Label = "Anthropic (Claude)" },
+            new UsageProviderOption { Key = "gemini",    Label = "Google Gemini" },
+            new UsageProviderOption { Key = "nemotron",  Label = "NVIDIA Nemotron" },
+        };
+
+        public ObservableCollection<UsageMeterRow> ModelRows { get; } = new();
+        public ObservableCollection<UsageTrendBar> TrendBars { get; } = new();
+        public ObservableCollection<UsageSessionRow> SessionRows { get; } = new();
+
+        // Selection ------------------------------------------------------------
+        [ObservableProperty] private string selectedRangeKey = "30d";
+        [ObservableProperty] private string selectedProviderKey = "all";
+
+        // Load state -----------------------------------------------------------
+        [ObservableProperty] private bool isBusy;
+
+        /// <summary>True once a response has been rendered. Distinguishes "still
+        /// loading for the first time" (skeleton/spinner) from "loaded but the
+        /// range is empty" (empty state).</summary>
+        [ObservableProperty] private bool hasMetrics;
+
+        [ObservableProperty] private string? errorMessage;
+
+        /// <summary>Mirrors the server's <c>usageRecordingEnabled</c>. When false
+        /// we surface an InfoBar: historical rows still render, but no new ones
+        /// are being written.</summary>
+        [ObservableProperty] private bool recordingEnabled = true;
+
+        // Rendered figures -----------------------------------------------------
+        [ObservableProperty] private string rangeLabel = "Last 30 days";
+        [ObservableProperty] private string providerLabel = "All Providers";
+        [ObservableProperty] private string totalTokensDisplay = "0";
+        [ObservableProperty] private string promptTokensDisplay = "0";
+        [ObservableProperty] private string completionTokensDisplay = "0";
+        [ObservableProperty] private string requestsSubtitle = "No calls recorded";
+        [ObservableProperty] private string promptShareSubtitle = "";
+        [ObservableProperty] private string completionShareSubtitle = "";
+        [ObservableProperty] private string averageDailyDisplay = "0";
+        [ObservableProperty] private string generatedAtDisplay = "";
+
+        /// <summary>True when the range returned zero calls — drives the "no
+        /// calls in this range" InfoBar (distinct from "nothing loaded yet").</summary>
+        [ObservableProperty] private bool isRangeEmpty;
+
+        public bool HasError => !string.IsNullOrWhiteSpace(ErrorMessage);
+        public bool ShowRecordingWarning => HasMetrics && !RecordingEnabled;
+
+        /// <summary>Spinner only replaces the dashboard on the very first load;
+        /// later refreshes keep the previous numbers on screen and just show the
+        /// inline busy ring so the page never flashes empty.</summary>
+        public bool ShowFirstLoadSkeleton => IsBusy && !HasMetrics;
+
+        /// <summary>Empty state: we finished loading and there is nothing to
+        /// show at all (no metrics object came back, or an error occurred).</summary>
+        public bool ShowEmptyState => !IsBusy && !HasMetrics;
+
+        public bool ShowDashboard => HasMetrics;
+        public bool HasModelRows => ModelRows.Count > 0;
+        public bool HasTrendBars => TrendBars.Count > 0;
+        public bool HasSessionRows => SessionRows.Count > 0;
+        public bool CanRefresh => !IsBusy;
+
+        /// <summary>Accent cycle for the per-model meters. Uses the shared Nord
+        /// accent tokens so the Usage page speaks the same colour vocabulary as
+        /// the OmniAgent session cards.</summary>
+        private static readonly string[] MeterAccentKeys =
+        {
+            "Nord.AccentBlueBrush",
+            "Nord.AccentPurpleBrush",
+            "Nord.AccentGreenBrush",
+            "Nord.AccentAmberBrush",
+        };
+
+        private static Brush Resource(string key) =>
+            System.Windows.Application.Current?.Resources[key] as Brush ?? Brushes.Gray;
+
+        private static Brush MeterAccent(int index) =>
+            Resource(MeterAccentKeys[index % MeterAccentKeys.Length]);
+
+        public Brush TotalAccentBrush      => Resource("Nord.AccentBrush");
+        public Brush PromptAccentBrush     => Resource("Nord.AccentGreenBrush");
+        public Brush CompletionAccentBrush => Resource("Nord.AccentPurpleBrush");
+        public Brush AverageAccentBrush    => Resource("Nord.AccentAmberBrush");
+        public Brush TrendPromptBrush      => Resource("Nord.AccentBlueBrush");
+        public Brush TrendCompletionBrush  => Resource("Nord.AccentGreenBrush");
+
+        // ---- Property-changed plumbing ---------------------------------------
+
+        partial void OnIsBusyChanged(bool value)
+        {
+            OnPropertyChanged(nameof(CanRefresh));
+            OnPropertyChanged(nameof(ShowFirstLoadSkeleton));
+            OnPropertyChanged(nameof(ShowEmptyState));
+            RefreshCommand.NotifyCanExecuteChanged();
+        }
+
+        partial void OnHasMetricsChanged(bool value)
+        {
+            OnPropertyChanged(nameof(ShowFirstLoadSkeleton));
+            OnPropertyChanged(nameof(ShowEmptyState));
+            OnPropertyChanged(nameof(ShowDashboard));
+            OnPropertyChanged(nameof(ShowRecordingWarning));
+        }
+
+        partial void OnRecordingEnabledChanged(bool value) =>
+            OnPropertyChanged(nameof(ShowRecordingWarning));
+
+        partial void OnErrorMessageChanged(string? value) =>
+            OnPropertyChanged(nameof(HasError));
+
+        // Changing either filter immediately refetches, matching the macOS
+        // pickers which reload on change rather than behind an Apply button.
+        partial void OnSelectedRangeKeyChanged(string value) => _ = RefreshAsync();
+        partial void OnSelectedProviderKeyChanged(string value) => _ = RefreshAsync();
+
+        // ---- Commands --------------------------------------------------------
+
+        [RelayCommand]
+        private void DismissError() => ErrorMessage = null;
+
+        [RelayCommand(CanExecute = nameof(CanRefresh))]
+        public async Task RefreshAsync()
+        {
+            // Supersede any in-flight request so rapid filter changes settle on
+            // the newest selection rather than whichever response lands last.
+            _inflight?.Cancel();
+            var cts = new CancellationTokenSource();
+            _inflight = cts;
+
+            IsBusy = true;
+            ErrorMessage = null;
+            try
+            {
+                var metrics = await _api.FetchUsageMetricsAsync(SelectedRangeKey, SelectedProviderKey);
+                if (cts.IsCancellationRequested) return;
+                Apply(metrics);
+                HasMetrics = true;
+            }
+            catch (OperationCanceledException)
+            {
+                // Superseded by a newer request — leave the UI to that one.
+            }
+            catch (Exception ex)
+            {
+                if (cts.IsCancellationRequested) return;
+                // Never throw at the user: the InfoBar carries the message and
+                // any previously loaded numbers stay on screen.
+                ErrorMessage = $"Couldn't load usage metrics: {ex.Message}";
+            }
+            finally
+            {
+                if (ReferenceEquals(_inflight, cts))
+                {
+                    IsBusy = false;
+                    _inflight = null;
+                }
+                cts.Dispose();
+            }
+        }
+
+        // ---- Projection ------------------------------------------------------
+
+        private void Apply(UsageMetricsResponse m)
+        {
+            RecordingEnabled = m.RecordingEnabled;
+            RangeLabel = string.IsNullOrWhiteSpace(m.Range.Label) ? "Selected range" : m.Range.Label;
+            ProviderLabel = string.IsNullOrWhiteSpace(m.Provider.ProviderLabel)
+                ? "All Providers"
+                : m.Provider.ProviderLabel;
+
+            int total = m.Totals.TotalTokens;
+            TotalTokensDisplay = FormatTokens(total);
+            PromptTokensDisplay = FormatTokens(m.Totals.PromptTokens);
+            CompletionTokensDisplay = FormatTokens(m.Totals.CompletionTokens);
+            AverageDailyDisplay = FormatTokens(m.Estimates.AverageDailyTokens);
+
+            string rangeLower = RangeLabel.ToLowerInvariant();
+            RequestsSubtitle = m.Totals.Requests == 1
+                ? $"1 call in {rangeLower}"
+                : $"{m.Totals.Requests} calls in {rangeLower}";
+            PromptShareSubtitle = TokenShare(m.Totals.PromptTokens, total);
+            CompletionShareSubtitle = TokenShare(m.Totals.CompletionTokens, total);
+            GeneratedAtDisplay = FormatDateTime(m.GeneratedAt);
+            IsRangeEmpty = m.Totals.Requests == 0;
+
+            BuildModelRows(m.ByModel);
+            BuildTrendBars(m.Daily);
+            BuildSessionRows(m.RecentSessions);
+        }
+
+        /// <summary>Top 8 models by tokens, matching the macOS cap so neither
+        /// client grows an unbounded list on a busy account.</summary>
+        private void BuildModelRows(List<UsageBucketDto> byModel)
+        {
+            ModelRows.Clear();
+            var buckets = byModel.Take(8).ToList();
+            int max = buckets.Count > 0 ? buckets.Max(b => b.TotalTokens) : 0;
+
+            for (int i = 0; i < buckets.Count; i++)
+            {
+                var b = buckets[i];
+                ModelRows.Add(new UsageMeterRow
+                {
+                    Label = string.IsNullOrWhiteSpace(b.Label) ? b.Key : b.Label,
+                    TokensDisplay = FormatTokens(b.TotalTokens),
+                    DetailDisplay = $"{b.Requests} {(b.Requests == 1 ? "call" : "calls")}  ·  "
+                                    + $"in {FormatTokens(b.PromptTokens)}  ·  out {FormatTokens(b.CompletionTokens)}",
+                    // Guard against a divide-by-zero when every bucket is empty.
+                    Percent = max > 0 ? b.TotalTokens * 100d / max : 0d,
+                    Accent = MeterAccent(i),
+                });
+            }
+            OnPropertyChanged(nameof(HasModelRows));
+        }
+
+        /// <summary>Last 32 days of the daily series (macOS uses the same
+        /// suffix) rendered as stacked input/output columns. Days with no tokens
+        /// are kept so gaps in activity stay visible.</summary>
+        private void BuildTrendBars(List<UsageBucketDto> daily)
+        {
+            TrendBars.Clear();
+            var buckets = daily.Count > 32 ? daily.Skip(daily.Count - 32).ToList() : daily;
+            int max = buckets.Count > 0 ? buckets.Max(b => b.TotalTokens) : 0;
+
+            // Nothing to plot: leave the collection empty so the section shows
+            // its own inline empty text rather than a row of zero-height bars.
+            if (max <= 0)
+            {
+                OnPropertyChanged(nameof(HasTrendBars));
+                return;
+            }
+
+            foreach (var b in buckets)
+            {
+                double scale = TrendChartHeight / max;
+                TrendBars.Add(new UsageTrendBar
+                {
+                    Label = ShortDate(b.Key),
+                    PromptHeight = Math.Round(b.PromptTokens * scale, 2),
+                    CompletionHeight = Math.Round(b.CompletionTokens * scale, 2),
+                    Tooltip = $"{ShortDate(b.Key)} — {FormatTokens(b.TotalTokens)} tokens "
+                              + $"(in {FormatTokens(b.PromptTokens)}, out {FormatTokens(b.CompletionTokens)})",
+                });
+            }
+            OnPropertyChanged(nameof(HasTrendBars));
+        }
+
+        private void BuildSessionRows(List<UsageSessionDto> sessions)
+        {
+            SessionRows.Clear();
+            foreach (var s in sessions.Take(5))
+            {
+                SessionRows.Add(new UsageSessionRow
+                {
+                    Title = string.IsNullOrWhiteSpace(s.Title) ? "Untitled Session" : s.Title,
+                    TokensDisplay = FormatTokens(s.TotalTokens),
+                    DetailDisplay = $"{s.Turns} {(s.Turns == 1 ? "turn" : "turns")}  ·  {ShortDate(s.LastActiveAt)}",
+                });
+            }
+            OnPropertyChanged(nameof(HasSessionRows));
+        }
+
+        // ---- Formatting ------------------------------------------------------
+        // Mirrors macOS UsageView.formatTokens: thousands as "12.3k", millions
+        // as "1.24M", so the metric cards never overflow their fixed width.
+
+        private static string FormatTokens(double tokens)
+        {
+            if (double.IsNaN(tokens) || double.IsInfinity(tokens) || tokens <= 0) return "0";
+            if (tokens >= 1_000_000) return (tokens / 1_000_000d).ToString("0.##", CultureInfo.InvariantCulture) + "M";
+            if (tokens >= 1_000)     return (tokens / 1_000d).ToString("0.#", CultureInfo.InvariantCulture) + "k";
+            return Math.Round(tokens).ToString("0", CultureInfo.InvariantCulture);
+        }
+
+        private static string TokenShare(int part, int total) =>
+            total <= 0 ? "No tokens recorded" : $"{part * 100d / total:0.#}% of total tokens";
+
+        /// <summary>Parses an ISO-8601 timestamp (or a bare <c>yyyy-MM-dd</c>
+        /// bucket key) into a short local date. Returns the raw value when it
+        /// isn't parseable so an unexpected server format degrades to text
+        /// rather than throwing.</summary>
+        private static string ShortDate(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value)) return "";
+            return DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture,
+                       DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var parsed)
+                ? parsed.ToLocalTime().ToString("MMM d", CultureInfo.CurrentCulture)
+                : value;
+        }
+
+        private static string FormatDateTime(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value)) return "";
+            return DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture,
+                       DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var parsed)
+                ? parsed.ToLocalTime().ToString("MMM d, HH:mm", CultureInfo.CurrentCulture)
+                : value;
+        }
+    }
+}

--- a/windows/Views/MainWindow.xaml
+++ b/windows/Views/MainWindow.xaml
@@ -97,6 +97,15 @@
                         <ui:SymbolIcon Symbol="Server24" />
                     </ui:NavigationViewItem.Icon>
                 </ui:NavigationViewItem>
+                <!--  Also reachable from Settings › Usage; promoted to the main
+                      rail because token spend is a routine check, not a setting.  -->
+                <ui:NavigationViewItem
+                    Content="Usage"
+                    TargetPageType="{x:Type pages:UsagePage}">
+                    <ui:NavigationViewItem.Icon>
+                        <ui:SymbolIcon Symbol="DataUsage24" />
+                    </ui:NavigationViewItem.Icon>
+                </ui:NavigationViewItem>
             </ui:NavigationView.MenuItems>
             <ui:NavigationView.FooterMenuItems>
                 <ui:NavigationViewItem

--- a/windows/Views/Pages/AgentSessionPage.xaml
+++ b/windows/Views/Pages/AgentSessionPage.xaml
@@ -173,7 +173,7 @@
                         FontFamily="{StaticResource OK.MonoFontFamily}"
                         FontSize="11.5"
                         Foreground="#FFDCDCE0"
-                        Text="{Binding Text}"
+                        Text="{Binding ExpandedSummary}"
                         TextWrapping="Wrap" />
                 </Border>
             </Grid>

--- a/windows/Views/Pages/ChatPage.xaml
+++ b/windows/Views/Pages/ChatPage.xaml
@@ -1301,6 +1301,73 @@
                             </StackPanel>
                         </Border>
 
+                        <!-- Agent model picker — mirrors the macOS composer
+                             AgentModelMenu. The chosen model is persisted in
+                             the agent_settings table for the active provider
+                             (PATCH /api/providers/{provider}/model), so it
+                             sticks across restarts. Hidden until options load;
+                             disabled while a turn is running so the recorded
+                             usage row can't disagree with the served model. -->
+                        <Border
+                            Margin="6,0,0,0"
+                            Padding="4,2,4,2"
+                            VerticalAlignment="Center"
+                            HorizontalAlignment="Left"
+                            CornerRadius="999"
+                            Visibility="{Binding HasAgentModelOptions, Converter={StaticResource BooleanToVisibilityConverter}}">
+                            <StackPanel VerticalAlignment="Center" Orientation="Horizontal">
+                                <!-- Swaps to a spinner while the PATCH is in
+                                     flight so the pill reports its own state. -->
+                                <ui:SymbolIcon
+                                    Margin="4,0,6,0"
+                                    VerticalAlignment="Center"
+                                    FontSize="13"
+                                    Foreground="{StaticResource Nord.AccentPurpleBrush}"
+                                    Symbol="Beaker24"
+                                    ToolTip="{Binding AgentModelTooltip}"
+                                    Visibility="{Binding IsUpdatingAgentModel, Converter={StaticResource InverseBooleanToVisibilityConverter}}" />
+                                <ui:ProgressRing
+                                    Width="13"
+                                    Height="13"
+                                    Margin="4,0,6,0"
+                                    VerticalAlignment="Center"
+                                    IsIndeterminate="True"
+                                    Visibility="{Binding IsUpdatingAgentModel, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                <ComboBox
+                                    MinWidth="150"
+                                    VerticalAlignment="Center"
+                                    AutomationProperties.Name="Agent model"
+                                    Background="Transparent"
+                                    BorderThickness="0"
+                                    DisplayMemberPath="Label"
+                                    FontFamily="{StaticResource OK.FontFamily}"
+                                    FontSize="12"
+                                    IsEnabled="{Binding CanChangeAgentModel}"
+                                    ItemsSource="{Binding AvailableAgentModels}"
+                                    SelectedValue="{Binding SelectedAgentModelId, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                    SelectedValuePath="Id"
+                                    ToolTip="{Binding AgentModelTooltip}">
+                                    <ComboBox.Resources>
+                                        <!-- Same borderless chrome as the sibling
+                                             chips; popup background untouched. -->
+                                        <SolidColorBrush x:Key="ControlFillColorDefaultBrush" Color="Transparent" />
+                                        <SolidColorBrush x:Key="ControlFillColorSecondaryBrush" Color="Transparent" />
+                                        <SolidColorBrush x:Key="ControlFillColorTertiaryBrush" Color="Transparent" />
+                                        <SolidColorBrush x:Key="ControlStrokeColorDefaultBrush" Color="Transparent" />
+                                        <SolidColorBrush x:Key="ControlStrokeColorSecondaryBrush" Color="Transparent" />
+                                        <SolidColorBrush x:Key="ComboBoxBackground" Color="Transparent" />
+                                        <SolidColorBrush x:Key="ComboBoxBackgroundPointerOver" Color="#1AFFFFFF" />
+                                        <SolidColorBrush x:Key="ComboBoxBackgroundFocused" Color="Transparent" />
+                                        <SolidColorBrush x:Key="ComboBoxBackgroundUnfocused" Color="Transparent" />
+                                        <SolidColorBrush x:Key="ComboBoxBackgroundDisabled" Color="Transparent" />
+                                        <SolidColorBrush x:Key="ComboBoxBorderBrush" Color="Transparent" />
+                                        <SolidColorBrush x:Key="ComboBoxBorderBrushPointerOver" Color="Transparent" />
+                                        <SolidColorBrush x:Key="ComboBoxBorderBrushFocused" Color="Transparent" />
+                                    </ComboBox.Resources>
+                                </ComboBox>
+                            </StackPanel>
+                        </Border>
+
                         </StackPanel>
 
                         <!-- Spacer between left chip and right cluster -->

--- a/windows/Views/Pages/ChatPage.xaml
+++ b/windows/Views/Pages/ChatPage.xaml
@@ -216,7 +216,7 @@
                         FontFamily="{StaticResource OK.MonoFontFamily}"
                         FontSize="11.5"
                         Foreground="#FFDCDCE0"
-                        Text="{Binding Text}"
+                        Text="{Binding ExpandedSummary}"
                         TextWrapping="Wrap" />
                 </Border>
             </Grid>
@@ -1156,14 +1156,14 @@
                     <!-- Bottom toolbar: task chip + context indicator + send/stop -->
                     <Grid Grid.Row="1" Margin="12,4,12,12">
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto" />
                             <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
                             <ColumnDefinition Width="Auto" />
                             <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
 
                         <!-- Composer pickers cluster (task instruction + project) -->
-                        <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center">
+                        <WrapPanel Grid.Column="0" VerticalAlignment="Center">
 
                                                 <!-- Task-instruction pill.
                                                      Two mutually-exclusive faces:
@@ -1194,14 +1194,14 @@
                                         Foreground="{StaticResource Nord.AccentBrush}"
                                         Symbol="TextBulletListSquare24" />
                                     <ComboBox
-                                        MinWidth="180"
+                                        Width="148"
                                         VerticalAlignment="Center"
                                         Background="Transparent"
                                         BorderThickness="0"
-                                        DisplayMemberPath="Heading"
                                         FontFamily="{StaticResource OK.FontFamily}"
                                         FontSize="12"
                                         ItemsSource="{Binding AvailableTaskTemplates}"
+                                        SelectedIndex="0"
                                         SelectedValue="{Binding SelectedDefaultTemplateId, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                         SelectedValuePath="Id">
                                         <ComboBox.Resources>
@@ -1223,6 +1223,14 @@
                                             <SolidColorBrush x:Key="ComboBoxBorderBrushPointerOver" Color="Transparent" />
                                             <SolidColorBrush x:Key="ComboBoxBorderBrushFocused" Color="Transparent" />
                                         </ComboBox.Resources>
+                                        <ComboBox.ItemTemplate>
+                                            <DataTemplate>
+                                                <TextBlock
+                                                    MaxWidth="220"
+                                                    Text="{Binding Heading}"
+                                                    TextTrimming="CharacterEllipsis" />
+                                            </DataTemplate>
+                                        </ComboBox.ItemTemplate>
                                     </ComboBox>
                                 </StackPanel>
 
@@ -1238,7 +1246,7 @@
                                         Foreground="{StaticResource Nord.AccentBrush}"
                                         Symbol="LockClosed24" />
                                     <TextBlock
-                                        MinWidth="180"
+                                        Width="148"
                                         VerticalAlignment="Center"
                                         FontFamily="{StaticResource OK.FontFamily}"
                                         FontSize="12"
@@ -1268,14 +1276,14 @@
                                     Symbol="Folder24"
                                     ToolTip="Project for this chat" />
                                 <ComboBox
-                                    MinWidth="160"
+                                    Width="128"
                                     VerticalAlignment="Center"
                                     Background="Transparent"
                                     BorderThickness="0"
-                                    DisplayMemberPath="DisplayName"
                                     FontFamily="{StaticResource OK.FontFamily}"
                                     FontSize="12"
                                     ItemsSource="{Binding AvailableProjectGroups}"
+                                    SelectedIndex="0"
                                     SelectedValue="{Binding SelectedProjectGroupName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                     SelectedValuePath="GroupName"
                                     ToolTip="Project this chat belongs to (mirrors macOS)">
@@ -1297,6 +1305,14 @@
                                         <SolidColorBrush x:Key="ComboBoxBorderBrushPointerOver" Color="Transparent" />
                                         <SolidColorBrush x:Key="ComboBoxBorderBrushFocused" Color="Transparent" />
                                     </ComboBox.Resources>
+                                    <ComboBox.ItemTemplate>
+                                        <DataTemplate>
+                                            <TextBlock
+                                                MaxWidth="220"
+                                                Text="{Binding DisplayName}"
+                                                TextTrimming="CharacterEllipsis" />
+                                        </DataTemplate>
+                                    </ComboBox.ItemTemplate>
                                 </ComboBox>
                             </StackPanel>
                         </Border>
@@ -1334,12 +1350,11 @@
                                     IsIndeterminate="True"
                                     Visibility="{Binding IsUpdatingAgentModel, Converter={StaticResource BooleanToVisibilityConverter}}" />
                                 <ComboBox
-                                    MinWidth="150"
+                                    Width="124"
                                     VerticalAlignment="Center"
                                     AutomationProperties.Name="Agent model"
                                     Background="Transparent"
                                     BorderThickness="0"
-                                    DisplayMemberPath="Label"
                                     FontFamily="{StaticResource OK.FontFamily}"
                                     FontSize="12"
                                     IsEnabled="{Binding CanChangeAgentModel}"
@@ -1364,14 +1379,22 @@
                                         <SolidColorBrush x:Key="ComboBoxBorderBrushPointerOver" Color="Transparent" />
                                         <SolidColorBrush x:Key="ComboBoxBorderBrushFocused" Color="Transparent" />
                                     </ComboBox.Resources>
+                                    <ComboBox.ItemTemplate>
+                                        <DataTemplate>
+                                            <TextBlock
+                                                MaxWidth="260"
+                                                Text="{Binding Label}"
+                                                TextTrimming="CharacterEllipsis" />
+                                        </DataTemplate>
+                                    </ComboBox.ItemTemplate>
                                 </ComboBox>
                             </StackPanel>
                         </Border>
 
-                        </StackPanel>
+                        </WrapPanel>
 
                         <!-- Spacer between left chip and right cluster -->
-                        <Border Grid.Column="1" />
+                        <Border Grid.Column="1" Width="8" />
 
                         <!-- Remaining context window — compact ring; tooltip
                              shows the exact tokens-left numbers. -->

--- a/windows/Views/Pages/SettingsPage.xaml
+++ b/windows/Views/Pages/SettingsPage.xaml
@@ -127,6 +127,22 @@
 
                 <Button
                     Command="{Binding SelectSectionCommand}"
+                    CommandParameter="{x:Static vm:SettingsSection.Usage}"
+                    Style="{StaticResource SidebarNavButton}"
+                    Tag="{Binding IsUsageSelected}">
+                    <StackPanel Orientation="Horizontal">
+                        <ui:SymbolIcon
+                            Margin="0,0,10,0"
+                            VerticalAlignment="Center"
+                            FontSize="16"
+                            Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"
+                            Symbol="DataUsage24" />
+                        <TextBlock VerticalAlignment="Center" Text="Usage" />
+                    </StackPanel>
+                </Button>
+
+                <Button
+                    Command="{Binding SelectSectionCommand}"
                     CommandParameter="{x:Static vm:SettingsSection.Updates}"
                     Style="{StaticResource SidebarNavButton}"
                     Tag="{Binding IsUpdatesSelected}">
@@ -388,7 +404,18 @@
                             FontFamily="{StaticResource OK.FontFamily}"
                             FontSize="{StaticResource OK.Font.Body}"
                             Foreground="{StaticResource Nord.SecondaryTextBrush}"
-                            Text="Control what agent sessions are allowed to do. Save to apply — the daemon restarts to pick up changes."
+                            Text="Control what agent sessions are allowed to do. Save to apply."
+                            TextWrapping="Wrap" />
+                        <!--  Settings moved out of environment variables into the
+                              agent_settings table, so there is no daemon restart
+                              any more. Surface where they live so the change in
+                              behaviour is discoverable.  -->
+                        <TextBlock
+                            Margin="0,6,0,0"
+                            FontFamily="{StaticResource OK.FontFamily}"
+                            FontSize="{StaticResource OK.Font.CaptionSmall}"
+                            Foreground="{StaticResource Nord.AccentBlueBrush}"
+                            Text="{Binding SettingsSourceSummary}"
                             TextWrapping="Wrap" />
                     </StackPanel>
 
@@ -458,6 +485,47 @@
                         </Grid>
                     </Border>
 
+                    <!--  Usage recording  -->
+                    <Border
+                        Margin="0,0,0,14"
+                        Padding="18,16"
+                        Background="{StaticResource Nord.PanelBackgroundBrush}"
+                        CornerRadius="14">
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <StackPanel Grid.Column="0" Margin="0,0,12,0">
+                                <TextBlock
+                                    FontFamily="{StaticResource OK.FontFamily}"
+                                    FontSize="{StaticResource OK.Font.Headline}"
+                                    FontWeight="SemiBold"
+                                    Foreground="{StaticResource Nord.PrimaryTextBrush}"
+                                    Text="Usage recording" />
+                                <TextBlock
+                                    Margin="0,4,0,0"
+                                    FontFamily="{StaticResource OK.FontFamily}"
+                                    FontSize="{StaticResource OK.Font.Caption}"
+                                    Foreground="{StaticResource Nord.SecondaryTextBrush}"
+                                    Text="Persist per-call token counts so the Usage page can show consumption trends."
+                                    TextWrapping="Wrap" />
+                                <TextBlock
+                                    Margin="0,6,0,0"
+                                    FontFamily="{StaticResource OK.FontFamily}"
+                                    FontSize="{StaticResource OK.Font.CaptionSmall}"
+                                    Foreground="{StaticResource Nord.SecondaryTextBrush}"
+                                    Text="Turning this off keeps existing rows but stops recording new ones."
+                                    TextWrapping="Wrap" />
+                            </StackPanel>
+                            <ui:ToggleSwitch
+                                Grid.Column="1"
+                                VerticalAlignment="Center"
+                                AutomationProperties.Name="Usage recording"
+                                IsChecked="{Binding PendingUsageRecordingEnabled, Mode=TwoWay}" />
+                        </Grid>
+                    </Border>
+
                     <!--  Browser access  -->
                     <Border
                         Margin="0,0,0,16"
@@ -506,6 +574,14 @@
                         Icon="{ui:SymbolIcon Symbol=Save24}" />
                 </StackPanel>
             </ScrollViewer>
+
+            <!--  =========== Usage (hosted page) ===========  -->
+            <Frame
+                x:Name="UsageFrame"
+                Grid.Row="0"
+                Background="Transparent"
+                NavigationUIVisibility="Hidden"
+                Visibility="{Binding IsUsageSelected, Converter={StaticResource BooleanToVisibilityConverter}}" />
 
             <!--  =========== Updates (hosted page) ===========  -->
             <Frame

--- a/windows/Views/Pages/SettingsPage.xaml.cs
+++ b/windows/Views/Pages/SettingsPage.xaml.cs
@@ -55,7 +55,11 @@ namespace OmniKey.Windows.Views.Pages
         {
             if (e.PropertyName != nameof(SettingsViewModel.SelectedSection)) return;
 
-            if (_vm.SelectedSection == SettingsSection.Updates && UpdatesFrame.Content is null)
+            // Lazy-navigate on first open so we don't fire UpdatesPage's version
+            // check or the Usage page's /api/usage fetch until they're asked for.
+            if (_vm.SelectedSection == SettingsSection.Usage && UsageFrame.Content is null)
+                UsageFrame.Navigate(new UsagePage());
+            else if (_vm.SelectedSection == SettingsSection.Updates && UpdatesFrame.Content is null)
                 UpdatesFrame.Navigate(new UpdatesPage());
             else if (_vm.SelectedSection == SettingsSection.Manual && ManualFrame.Content is null)
                 ManualFrame.Navigate(new ManualPage());

--- a/windows/Views/Pages/UsagePage.xaml
+++ b/windows/Views/Pages/UsagePage.xaml
@@ -1,0 +1,600 @@
+<Page
+    x:Class="OmniKey.Windows.Views.Pages.UsagePage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
+    xmlns:vm="clr-namespace:OmniKey.Windows.ViewModels"
+    Title="Usage"
+    Background="Transparent"
+    d:DesignHeight="760"
+    d:DesignWidth="980"
+    mc:Ignorable="d">
+
+    <Page.Resources>
+        <!--  Metric card: the four headline token counters. Page-local because
+              the layout (icon + eyebrow + big number + share subtitle) is
+              specific to this dashboard.  -->
+        <Style x:Key="UsageCard" TargetType="Border">
+            <Setter Property="Padding" Value="16" />
+            <Setter Property="CornerRadius" Value="10" />
+            <Setter Property="Background" Value="{StaticResource Nord.PanelBackgroundBrush}" />
+            <Setter Property="BorderBrush" Value="{StaticResource Nord.BorderBrush}" />
+            <Setter Property="BorderThickness" Value="1" />
+        </Style>
+
+        <!--  Section container shared by the trend / model / session panels.  -->
+        <Style x:Key="UsageSection" TargetType="Border" BasedOn="{StaticResource UsageCard}">
+            <Setter Property="Margin" Value="0,0,0,12" />
+        </Style>
+
+        <Style x:Key="CardEyebrow" TargetType="TextBlock">
+            <Setter Property="FontFamily" Value="{StaticResource OK.FontFamily}" />
+            <Setter Property="FontSize" Value="{StaticResource OK.Font.Caption}" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="Foreground" Value="{StaticResource Nord.SecondaryTextBrush}" />
+            <Setter Property="TextTrimming" Value="CharacterEllipsis" />
+        </Style>
+
+        <Style x:Key="CardValue" TargetType="TextBlock">
+            <Setter Property="Margin" Value="0,8,0,0" />
+            <Setter Property="FontFamily" Value="{StaticResource OK.FontFamily}" />
+            <Setter Property="FontSize" Value="{StaticResource OK.Font.Display}" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="Foreground" Value="{StaticResource Nord.PrimaryTextBrush}" />
+        </Style>
+
+        <Style x:Key="CardSubtitle" TargetType="TextBlock">
+            <Setter Property="Margin" Value="0,4,0,0" />
+            <Setter Property="FontFamily" Value="{StaticResource OK.FontFamily}" />
+            <Setter Property="FontSize" Value="{StaticResource OK.Font.CaptionSmall}" />
+            <Setter Property="Foreground" Value="{StaticResource Nord.SecondaryTextBrush}" />
+            <Setter Property="TextWrapping" Value="Wrap" />
+        </Style>
+
+        <Style x:Key="SectionTitle" TargetType="TextBlock">
+            <Setter Property="FontFamily" Value="{StaticResource OK.FontFamily}" />
+            <Setter Property="FontSize" Value="{StaticResource OK.Font.Headline}" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="Foreground" Value="{StaticResource Nord.PrimaryTextBrush}" />
+        </Style>
+
+        <Style x:Key="SectionSubtitle" TargetType="TextBlock">
+            <Setter Property="Margin" Value="0,2,0,0" />
+            <Setter Property="FontFamily" Value="{StaticResource OK.FontFamily}" />
+            <Setter Property="FontSize" Value="{StaticResource OK.Font.CaptionSmall}" />
+            <Setter Property="Foreground" Value="{StaticResource Nord.SecondaryTextBrush}" />
+            <Setter Property="TextWrapping" Value="Wrap" />
+        </Style>
+
+        <!--  Inline "nothing in this range" text used inside a populated
+              dashboard, distinct from the page-level empty state.  -->
+        <Style x:Key="MiniEmpty" TargetType="TextBlock">
+            <Setter Property="Margin" Value="0,12,0,4" />
+            <Setter Property="FontFamily" Value="{StaticResource OK.FontFamily}" />
+            <Setter Property="FontSize" Value="{StaticResource OK.Font.Caption}" />
+            <Setter Property="Foreground" Value="{StaticResource Nord.SecondaryTextBrush}" />
+            <Setter Property="TextWrapping" Value="Wrap" />
+        </Style>
+    </Page.Resources>
+
+    <Grid Margin="24,20,24,20">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <!-- ─────────────────────── Header ─────────────────────── -->
+        <Grid Grid.Row="0" Margin="0,0,0,14">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+
+            <StackPanel Grid.Column="0" Margin="0,0,12,0">
+                <TextBlock
+                    FontFamily="{StaticResource OK.FontFamily}"
+                    FontSize="{StaticResource OK.Font.Title}"
+                    FontWeight="SemiBold"
+                    Foreground="{StaticResource Nord.PrimaryTextBrush}"
+                    Text="Usage" />
+                <TextBlock
+                    Margin="0,4,0,0"
+                    FontFamily="{StaticResource OK.FontFamily}"
+                    FontSize="{StaticResource OK.Font.Body}"
+                    Foreground="{StaticResource Nord.SecondaryTextBrush}"
+                    Text="Token consumption recorded for your agent and chat sessions."
+                    TextWrapping="Wrap" />
+            </StackPanel>
+
+            <StackPanel
+                Grid.Column="1"
+                VerticalAlignment="Top"
+                Orientation="Horizontal">
+                <!--  Inline ring for refreshes after the first load: the
+                      dashboard keeps its numbers so the page never flashes.  -->
+                <ui:ProgressRing
+                    Width="16"
+                    Height="16"
+                    Margin="0,0,10,0"
+                    VerticalAlignment="Center"
+                    IsIndeterminate="True"
+                    Visibility="{Binding IsBusy, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                <ui:Button
+                    Appearance="Secondary"
+                    AutomationProperties.Name="Refresh usage metrics"
+                    Command="{Binding RefreshCommand}"
+                    Content="Refresh"
+                    Icon="{ui:SymbolIcon Symbol=ArrowSync24, FontSize=14}"
+                    ToolTip="Reload usage metrics (F5)" />
+            </StackPanel>
+        </Grid>
+
+        <!-- ─────────────────────── Controls bar ─────────────────────── -->
+        <Grid Grid.Row="1" Margin="0,0,0,14">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+
+            <StackPanel Grid.Column="0" Margin="0,0,16,0">
+                <TextBlock
+                    Margin="0,0,0,6"
+                    FontFamily="{StaticResource OK.FontFamily}"
+                    FontSize="{StaticResource OK.Font.CaptionSmall}"
+                    FontWeight="SemiBold"
+                    Foreground="{StaticResource Nord.SecondaryTextBrush}"
+                    Text="{Binding Source='Range', Converter={StaticResource ToUpper}}" />
+                <ComboBox
+                    MinWidth="150"
+                    AutomationProperties.Name="Usage date range"
+                    DisplayMemberPath="Label"
+                    FontFamily="{StaticResource OK.FontFamily}"
+                    FontSize="{StaticResource OK.Font.Body}"
+                    IsEnabled="{Binding CanRefresh}"
+                    ItemsSource="{Binding RangeOptions}"
+                    SelectedValue="{Binding SelectedRangeKey, Mode=TwoWay}"
+                    SelectedValuePath="Key" />
+            </StackPanel>
+
+            <StackPanel Grid.Column="1">
+                <TextBlock
+                    Margin="0,0,0,6"
+                    FontFamily="{StaticResource OK.FontFamily}"
+                    FontSize="{StaticResource OK.Font.CaptionSmall}"
+                    FontWeight="SemiBold"
+                    Foreground="{StaticResource Nord.SecondaryTextBrush}"
+                    Text="{Binding Source='Provider', Converter={StaticResource ToUpper}}" />
+                <ComboBox
+                    MinWidth="190"
+                    AutomationProperties.Name="Usage provider filter"
+                    DisplayMemberPath="Label"
+                    FontFamily="{StaticResource OK.FontFamily}"
+                    FontSize="{StaticResource OK.Font.Body}"
+                    IsEnabled="{Binding CanRefresh}"
+                    ItemsSource="{Binding ProviderOptions}"
+                    SelectedValue="{Binding SelectedProviderKey, Mode=TwoWay}"
+                    SelectedValuePath="Key" />
+            </StackPanel>
+        </Grid>
+
+        <!-- ─────────────────────── Content ─────────────────────── -->
+        <Grid Grid.Row="2">
+
+            <!--  Error: recoverable, so it rides above the dashboard as an
+                  InfoBar rather than replacing it or raising a MessageBox.  -->
+            <ui:InfoBar
+                VerticalAlignment="Top"
+                Panel.ZIndex="10"
+                IsClosable="True"
+                IsOpen="{Binding HasError, Mode=OneWay}"
+                Message="{Binding ErrorMessage}"
+                Severity="Error"
+                Title="Usage unavailable" />
+
+            <!--  First load only: the dashboard has nothing to preserve yet.  -->
+            <StackPanel
+                VerticalAlignment="Center"
+                HorizontalAlignment="Center"
+                Visibility="{Binding ShowFirstLoadSkeleton, Converter={StaticResource BooleanToVisibilityConverter}}">
+                <ui:ProgressRing
+                    Width="34"
+                    Height="34"
+                    HorizontalAlignment="Center"
+                    IsIndeterminate="True" />
+                <TextBlock
+                    Margin="0,12,0,0"
+                    HorizontalAlignment="Center"
+                    FontFamily="{StaticResource OK.FontFamily}"
+                    FontSize="{StaticResource OK.Font.Body}"
+                    Foreground="{StaticResource Nord.SecondaryTextBrush}"
+                    Text="Loading usage metrics…" />
+            </StackPanel>
+
+            <!--  Empty state: nothing loaded (offline, or the very first run
+                  before any call was recorded).  -->
+            <StackPanel
+                MaxWidth="380"
+                VerticalAlignment="Center"
+                HorizontalAlignment="Center"
+                Visibility="{Binding ShowEmptyState, Converter={StaticResource BooleanToVisibilityConverter}}">
+                <ui:SymbolIcon
+                    HorizontalAlignment="Center"
+                    FontSize="38"
+                    Foreground="{StaticResource Nord.SecondaryTextBrush}"
+                    Symbol="DataUsage24" />
+                <TextBlock
+                    Margin="0,12,0,0"
+                    HorizontalAlignment="Center"
+                    FontFamily="{StaticResource OK.FontFamily}"
+                    FontSize="{StaticResource OK.Font.Headline}"
+                    FontWeight="SemiBold"
+                    Foreground="{StaticResource Nord.PrimaryTextBrush}"
+                    Text="No usage metrics loaded" />
+                <TextBlock
+                    Margin="0,6,0,0"
+                    HorizontalAlignment="Center"
+                    FontFamily="{StaticResource OK.FontFamily}"
+                    FontSize="{StaticResource OK.Font.Body}"
+                    Foreground="{StaticResource Nord.SecondaryTextBrush}"
+                    Text="Refresh to load token usage, or enable usage recording in Settings › Agent Access so new calls are captured."
+                    TextAlignment="Center"
+                    TextWrapping="Wrap" />
+                <ui:Button
+                    Margin="0,16,0,0"
+                    HorizontalAlignment="Center"
+                    Appearance="Primary"
+                    Command="{Binding RefreshCommand}"
+                    Content="Load usage"
+                    Icon="{ui:SymbolIcon Symbol=ArrowSync24, FontSize=14}" />
+            </StackPanel>
+
+            <!-- ─────────── Dashboard ─────────── -->
+            <ScrollViewer
+                VerticalScrollBarVisibility="Auto"
+                Visibility="{Binding ShowDashboard, Converter={StaticResource BooleanToVisibilityConverter}}">
+                <StackPanel>
+
+                    <!--  Recording is off: historical rows still render, but
+                          nothing new is being written. Warning, not an error.  -->
+                    <ui:InfoBar
+                        Margin="0,0,0,12"
+                        IsClosable="False"
+                        IsOpen="{Binding ShowRecordingWarning, Mode=OneWay}"
+                        Message="Historical rows are still shown. New token rows will only be captured after you enable usage recording in Settings › Agent Access."
+                        Severity="Warning"
+                        Title="Usage recording is off" />
+
+                    <!--  Range has no calls — distinct from "nothing loaded".  -->
+                    <ui:InfoBar
+                        Margin="0,0,0,12"
+                        IsClosable="False"
+                        IsOpen="{Binding IsRangeEmpty, Mode=OneWay}"
+                        Message="Switch ranges to inspect older usage, or make an AI call to start populating this view."
+                        Severity="Informational"
+                        Title="No calls in the selected range" />
+
+                    <!--  Four headline counters. UniformGrid keeps them equal
+                          width and wraps to 2×2 on narrow windows.  -->
+                    <UniformGrid Margin="0,0,0,12" Columns="4" Rows="1">
+                        <Border Margin="0,0,12,0" Style="{StaticResource UsageCard}">
+                            <StackPanel>
+                                <StackPanel Orientation="Horizontal">
+                                    <ui:SymbolIcon
+                                        Margin="0,0,7,0"
+                                        VerticalAlignment="Center"
+                                        FontSize="14"
+                                        Foreground="{Binding TotalAccentBrush}"
+                                        Symbol="DataUsage24" />
+                                    <TextBlock Style="{StaticResource CardEyebrow}" Text="Total Tokens Used" />
+                                </StackPanel>
+                                <TextBlock Style="{StaticResource CardValue}" Text="{Binding TotalTokensDisplay}" />
+                                <TextBlock Style="{StaticResource CardSubtitle}" Text="{Binding RequestsSubtitle}" />
+                            </StackPanel>
+                        </Border>
+
+                        <Border Margin="0,0,12,0" Style="{StaticResource UsageCard}">
+                            <StackPanel>
+                                <StackPanel Orientation="Horizontal">
+                                    <ui:SymbolIcon
+                                        Margin="0,0,7,0"
+                                        VerticalAlignment="Center"
+                                        FontSize="14"
+                                        Foreground="{Binding PromptAccentBrush}"
+                                        Symbol="ArrowDownload24" />
+                                    <TextBlock Style="{StaticResource CardEyebrow}" Text="Input Tokens Used" />
+                                </StackPanel>
+                                <TextBlock Style="{StaticResource CardValue}" Text="{Binding PromptTokensDisplay}" />
+                                <TextBlock Style="{StaticResource CardSubtitle}" Text="{Binding PromptShareSubtitle}" />
+                            </StackPanel>
+                        </Border>
+
+                        <Border Margin="0,0,12,0" Style="{StaticResource UsageCard}">
+                            <StackPanel>
+                                <StackPanel Orientation="Horizontal">
+                                    <ui:SymbolIcon
+                                        Margin="0,0,7,0"
+                                        VerticalAlignment="Center"
+                                        FontSize="14"
+                                        Foreground="{Binding CompletionAccentBrush}"
+                                        Symbol="ArrowUpload24" />
+                                    <TextBlock Style="{StaticResource CardEyebrow}" Text="Output Tokens Used" />
+                                </StackPanel>
+                                <TextBlock Style="{StaticResource CardValue}" Text="{Binding CompletionTokensDisplay}" />
+                                <TextBlock Style="{StaticResource CardSubtitle}" Text="{Binding CompletionShareSubtitle}" />
+                            </StackPanel>
+                        </Border>
+
+                        <Border Style="{StaticResource UsageCard}">
+                            <StackPanel>
+                                <StackPanel Orientation="Horizontal">
+                                    <ui:SymbolIcon
+                                        Margin="0,0,7,0"
+                                        VerticalAlignment="Center"
+                                        FontSize="14"
+                                        Foreground="{Binding AverageAccentBrush}"
+                                        Symbol="ChartMultiple24" />
+                                    <TextBlock Style="{StaticResource CardEyebrow}" Text="Avg Tokens / Day" />
+                                </StackPanel>
+                                <TextBlock Style="{StaticResource CardValue}" Text="{Binding AverageDailyDisplay}" />
+                                <TextBlock Style="{StaticResource CardSubtitle}" Text="{Binding RangeLabel}" />
+                            </StackPanel>
+                        </Border>
+                    </UniformGrid>
+
+                    <!-- ── Daily token split ── -->
+                    <Border Style="{StaticResource UsageSection}">
+                        <StackPanel>
+                            <StackPanel Orientation="Horizontal">
+                                <ui:SymbolIcon
+                                    Margin="0,2,8,0"
+                                    VerticalAlignment="Top"
+                                    FontSize="14"
+                                    Foreground="{StaticResource Nord.AccentBrush}"
+                                    Symbol="ChartMultiple24" />
+                                <StackPanel>
+                                    <TextBlock Style="{StaticResource SectionTitle}" Text="Daily Token Split" />
+                                    <TextBlock Style="{StaticResource SectionSubtitle}" Text="Input and output tokens per day." />
+                                </StackPanel>
+                            </StackPanel>
+
+                            <TextBlock
+                                Style="{StaticResource MiniEmpty}"
+                                Text="No daily token data in this range."
+                                Visibility="{Binding HasTrendBars, Converter={StaticResource InverseBooleanToVisibilityConverter}}" />
+
+                            <!--  Bars are stacked bottom-up: output sits on top
+                                  of input, both pre-scaled in the view-model so
+                                  no layout converter is needed.  -->
+                            <ItemsControl
+                                Height="110"
+                                Margin="0,14,0,0"
+                                VerticalAlignment="Bottom"
+                                ItemsSource="{Binding TrendBars}"
+                                Visibility="{Binding HasTrendBars, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                <ItemsControl.ItemsPanel>
+                                    <ItemsPanelTemplate>
+                                        <StackPanel Orientation="Horizontal" VerticalAlignment="Bottom" />
+                                    </ItemsPanelTemplate>
+                                </ItemsControl.ItemsPanel>
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate DataType="{x:Type vm:UsageTrendBar}">
+                                        <StackPanel
+                                            Width="14"
+                                            Margin="0,0,3,0"
+                                            VerticalAlignment="Bottom"
+                                            ToolTip="{Binding Tooltip}">
+                                            <Rectangle
+                                                Height="{Binding CompletionHeight}"
+                                                Fill="{Binding DataContext.TrendCompletionBrush, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                                RadiusX="2"
+                                                RadiusY="2" />
+                                            <Rectangle
+                                                Height="{Binding PromptHeight}"
+                                                Margin="0,1,0,0"
+                                                Fill="{Binding DataContext.TrendPromptBrush, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                                RadiusX="2"
+                                                RadiusY="2" />
+                                        </StackPanel>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+
+                            <!--  Legend  -->
+                            <StackPanel
+                                Margin="0,10,0,0"
+                                Orientation="Horizontal"
+                                Visibility="{Binding HasTrendBars, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                <Ellipse
+                                    Width="8"
+                                    Height="8"
+                                    Margin="0,0,6,0"
+                                    VerticalAlignment="Center"
+                                    Fill="{Binding TrendPromptBrush}" />
+                                <TextBlock
+                                    Margin="0,0,16,0"
+                                    VerticalAlignment="Center"
+                                    FontFamily="{StaticResource OK.FontFamily}"
+                                    FontSize="{StaticResource OK.Font.CaptionSmall}"
+                                    Foreground="{StaticResource Nord.SecondaryTextBrush}"
+                                    Text="Input" />
+                                <Ellipse
+                                    Width="8"
+                                    Height="8"
+                                    Margin="0,0,6,0"
+                                    VerticalAlignment="Center"
+                                    Fill="{Binding TrendCompletionBrush}" />
+                                <TextBlock
+                                    VerticalAlignment="Center"
+                                    FontFamily="{StaticResource OK.FontFamily}"
+                                    FontSize="{StaticResource OK.Font.CaptionSmall}"
+                                    Foreground="{StaticResource Nord.SecondaryTextBrush}"
+                                    Text="Output" />
+                            </StackPanel>
+                        </StackPanel>
+                    </Border>
+
+                    <!-- ── Tokens by model ── -->
+                    <Border Style="{StaticResource UsageSection}">
+                        <StackPanel>
+                            <StackPanel Orientation="Horizontal">
+                                <ui:SymbolIcon
+                                    Margin="0,2,8,0"
+                                    VerticalAlignment="Top"
+                                    FontSize="14"
+                                    Foreground="{StaticResource Nord.AccentBrush}"
+                                    Symbol="Beaker24" />
+                                <StackPanel>
+                                    <TextBlock Style="{StaticResource SectionTitle}" Text="Tokens by Model" />
+                                    <TextBlock Style="{StaticResource SectionSubtitle}" Text="Recorded tokens grouped by model, largest first." />
+                                </StackPanel>
+                            </StackPanel>
+
+                            <TextBlock
+                                Style="{StaticResource MiniEmpty}"
+                                Text="No model token data in this range."
+                                Visibility="{Binding HasModelRows, Converter={StaticResource InverseBooleanToVisibilityConverter}}" />
+
+                            <ItemsControl
+                                Margin="0,12,0,0"
+                                ItemsSource="{Binding ModelRows}"
+                                Visibility="{Binding HasModelRows, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate DataType="{x:Type vm:UsageMeterRow}">
+                                        <StackPanel Margin="0,0,0,12">
+                                            <Grid>
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="*" />
+                                                    <ColumnDefinition Width="Auto" />
+                                                </Grid.ColumnDefinitions>
+                                                <TextBlock
+                                                    Grid.Column="0"
+                                                    Margin="0,0,12,0"
+                                                    FontFamily="{StaticResource OK.FontFamily}"
+                                                    FontSize="{StaticResource OK.Font.Caption}"
+                                                    Foreground="{StaticResource Nord.PrimaryTextBrush}"
+                                                    Text="{Binding Label}"
+                                                    TextTrimming="CharacterEllipsis" />
+                                                <TextBlock
+                                                    Grid.Column="1"
+                                                    FontFamily="{StaticResource OK.MonoFontFamily}"
+                                                    FontSize="{StaticResource OK.Font.MonoInline}"
+                                                    FontWeight="SemiBold"
+                                                    Foreground="{StaticResource Nord.PrimaryTextBrush}"
+                                                    Text="{Binding TokensDisplay}" />
+                                            </Grid>
+
+                                            <!--  Determinate meter carrying the
+                                                  share of the largest bucket
+                                                  (0-100). Wpf.Ui has no
+                                                  ui:ProgressBar in 4.3.0, so this
+                                                  is the framework ProgressBar,
+                                                  which the Fluent theme already
+                                                  restyles.  -->
+                                            <ProgressBar
+                                                Height="6"
+                                                Margin="0,6,0,0"
+                                                AutomationProperties.Name="{Binding Label}"
+                                                Background="{StaticResource Nord.BorderBrush}"
+                                                BorderThickness="0"
+                                                Foreground="{Binding Accent}"
+                                                Maximum="100"
+                                                Value="{Binding Percent, Mode=OneWay}" />
+
+                                            <TextBlock
+                                                Margin="0,5,0,0"
+                                                FontFamily="{StaticResource OK.FontFamily}"
+                                                FontSize="{StaticResource OK.Font.CaptionSmall}"
+                                                Foreground="{StaticResource Nord.SecondaryTextBrush}"
+                                                Text="{Binding DetailDisplay}"
+                                                TextTrimming="CharacterEllipsis" />
+                                        </StackPanel>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </StackPanel>
+                    </Border>
+
+                    <!-- ── Recent sessions ── -->
+                    <Border Style="{StaticResource UsageSection}">
+                        <StackPanel>
+                            <StackPanel Orientation="Horizontal">
+                                <ui:SymbolIcon
+                                    Margin="0,2,8,0"
+                                    VerticalAlignment="Top"
+                                    FontSize="14"
+                                    Foreground="{StaticResource Nord.AccentBrush}"
+                                    Symbol="Chat24" />
+                                <StackPanel>
+                                    <TextBlock Style="{StaticResource SectionTitle}" Text="Recent Sessions" />
+                                    <TextBlock Style="{StaticResource SectionSubtitle}" Text="Last five sessions with recorded tokens." />
+                                </StackPanel>
+                            </StackPanel>
+
+                            <TextBlock
+                                Style="{StaticResource MiniEmpty}"
+                                Text="No session token totals in this range."
+                                Visibility="{Binding HasSessionRows, Converter={StaticResource InverseBooleanToVisibilityConverter}}" />
+
+                            <ItemsControl
+                                Margin="0,12,0,0"
+                                ItemsSource="{Binding SessionRows}"
+                                Visibility="{Binding HasSessionRows, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate DataType="{x:Type vm:UsageSessionRow}">
+                                        <Grid Margin="0,0,0,10" MinHeight="36">
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="*" />
+                                                <ColumnDefinition Width="Auto" />
+                                            </Grid.ColumnDefinitions>
+                                            <StackPanel Grid.Column="0" Margin="0,0,12,0">
+                                                <TextBlock
+                                                    FontFamily="{StaticResource OK.FontFamily}"
+                                                    FontSize="{StaticResource OK.Font.Caption}"
+                                                    Foreground="{StaticResource Nord.PrimaryTextBrush}"
+                                                    Text="{Binding Title}"
+                                                    TextTrimming="CharacterEllipsis" />
+                                                <TextBlock
+                                                    Margin="0,3,0,0"
+                                                    FontFamily="{StaticResource OK.FontFamily}"
+                                                    FontSize="{StaticResource OK.Font.CaptionSmall}"
+                                                    Foreground="{StaticResource Nord.SecondaryTextBrush}"
+                                                    Text="{Binding DetailDisplay}"
+                                                    TextTrimming="CharacterEllipsis" />
+                                            </StackPanel>
+                                            <TextBlock
+                                                Grid.Column="1"
+                                                VerticalAlignment="Center"
+                                                FontFamily="{StaticResource OK.MonoFontFamily}"
+                                                FontSize="{StaticResource OK.Font.MonoInline}"
+                                                FontWeight="SemiBold"
+                                                Foreground="{StaticResource Nord.PrimaryTextBrush}"
+                                                Text="{Binding TokensDisplay}" />
+                                        </Grid>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </StackPanel>
+                    </Border>
+
+                    <!--  Footer: provenance of the numbers on screen.  -->
+                    <TextBlock
+                        Margin="2,2,0,0"
+                        FontFamily="{StaticResource OK.FontFamily}"
+                        FontSize="{StaticResource OK.Font.CaptionSmall}"
+                        Foreground="{StaticResource Nord.SecondaryTextBrush}"
+                        TextTrimming="CharacterEllipsis">
+                        <Run Text="{Binding ProviderLabel, Mode=OneWay}" />
+                        <Run Text="·" />
+                        <Run Text="{Binding RangeLabel, Mode=OneWay}" />
+                        <Run Text="· updated" />
+                        <Run Text="{Binding GeneratedAtDisplay, Mode=OneWay}" />
+                    </TextBlock>
+                </StackPanel>
+            </ScrollViewer>
+        </Grid>
+    </Grid>
+</Page>

--- a/windows/Views/Pages/UsagePage.xaml.cs
+++ b/windows/Views/Pages/UsagePage.xaml.cs
@@ -1,0 +1,34 @@
+using System.Windows.Controls;
+using System.Windows.Input;
+using OmniKey.Windows.ViewModels;
+
+namespace OmniKey.Windows.Views.Pages
+{
+    /// <summary>
+    /// Token-usage dashboard. Mirrors the macOS UsageView tab: range +
+    /// provider filters over <c>GET /api/usage</c>, four headline counters and
+    /// three breakdown sections. Cost figures are intentionally absent — the
+    /// backend dropped them because provider price estimates can't be
+    /// reconciled with invoices.
+    /// </summary>
+    public partial class UsagePage : Page
+    {
+        private readonly UsageViewModel _vm;
+
+        public UsagePage()
+        {
+            InitializeComponent();
+            _vm = new UsageViewModel();
+            DataContext = _vm;
+
+            // F5 refreshes, matching the rest of the shell's list pages.
+            InputBindings.Add(new KeyBinding(_vm.RefreshCommand, Key.F5, ModifierKeys.None));
+
+            Loaded += async (_, _) =>
+            {
+                if (_vm.RefreshCommand.CanExecute(null))
+                    await _vm.RefreshCommand.ExecuteAsync(null);
+            };
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Brings the **Windows** client to parity with the macOS app on three fronts, and pulls in the matching Telegram `/model` support.

### 1. Usage page (mirrors macOS `UsageView`)
New `UsagePage` + `UsageViewModel` reading `GET /api/usage`.

- **Filters** — range (`7d` / `30d` / `month` / `90d` / `all`) and provider, using the same keys as macOS so both clients request identical windows.
- **Content** — four headline counters (total / input / output / avg-per-day), a daily input-vs-output trend chart, per-model meters (top 8), and the five most recent sessions by tokens.
- **No cost figures** — deliberate: the backend dropped them because provider price estimates can't be reconciled with invoices, so the page reports only what we can state accurately.
- **State coverage** — first-load spinner, empty state with a primary CTA, per-section inline empties, `ui:InfoBar` for errors plus the *"recording is off"* and *"no calls in range"* cases. `F5` refreshes; in-flight requests are superseded so rapid filter changes settle on the newest selection rather than whichever response lands last.
- **Entry points** — main nav rail **and** Settings › Usage (lazily navigated, so `/api/usage` isn't hit until opened).

### 2. Agent model switching in chat
- `ChatModel` gains `ActiveAIProvider` / `ActiveAgentModel` / options plus `FetchAgentModelOptions()` and `SetAgentModel()`, mirroring the macOS `AgentModelMenu`. Optimistic update with rollback + error surfacing on failure.
- Composer gains a **model pill** beside the task and project chips. Hidden until options load; disabled mid-turn so a recorded usage row can't disagree with the model that actually served the request.
- Falls back to a local option list byte-identical to the server's `AGENT_MODEL_OPTIONS` when an older daemon omits `modelOptions`.

### 3. Settings now read/write `agent_settings`
The settings page was backed by environment variables; every edit wrote an env var and required a daemon restart. That's no longer how the backend works.

- Agent-access settings are read from and written to the **`agent_settings` table**, so edits apply on the next agent turn with **no restart**. Copy and status messages updated to match, plus a footnote surfacing where values are stored (driven by the API's `source` field).
- **New "Usage recording" toggle** wired to `usageRecordingEnabled` — this is what populates the Usage page.
- All three toggles now go out in a **single** `PATCH /api/app-settings`.

### 4. Telegram (included per request)
`/model` command and inline model picker in the session wizard, backed by new `fetchAIProviders` / `updateProviderModel` helpers. Also adds a 30-minute idle timeout on agent WebSocket runs and graceful handling of empty `shell_script` requests.

## Files

| Area | Files |
|---|---|
| API layer | `windows/ApiClient.cs` |
| Runtime | `windows/ChatModel.cs` |
| ViewModels | `ChatViewModel.cs`, `SettingsViewModel.cs`, **`UsageViewModel.cs`** (new) |
| Views | `MainWindow.xaml`, `ChatPage.xaml`, `SettingsPage.xaml(.cs)`, **`UsagePage.xaml(.cs)`** (new) |
| Telegram | `agentClient.ts`, `notifyTelegram.ts` |

## Conventions

- No hard-coded colours, sizes or fonts — everything resolves through existing `Nord.*` / `OK.Font.*` tokens.
- `Nord.AccentAmber*` left untouched despite now being cyan, per the brief.
- MVVM throughout: `[ObservableProperty]` / `[RelayCommand]`, no logic in code-behind beyond view wiring and the `F5` key binding.
- Errors route through `ui:InfoBar` — no `MessageBox` flows added.
- `AutomationProperties.Name` on icon-only and meter controls.
- No new dependencies.

One deviation worth flagging: the per-model meter uses the **framework** `ProgressBar` rather than a Fluent equivalent — WPF-UI 4.3.0 ships no `ui:ProgressBar`, and the Fluent theme already restyles the built-in one. Noted inline in the XAML.

## Verification

- `dotnet build -c Debug` → **succeeded, 0 warnings / 0 errors**
- `dotnet build -c Release` → **succeeded, 0 warnings / 0 errors**
- `npx tsc -p telegram --noEmit` → **clean**
- Every `{Binding}` path in the new/changed XAML checked against its ViewModel — all resolve.
- All `ui:SymbolIcon` glyphs verified present in the WPF-UI 4.3.0 assembly.
- No `bin/`, `obj/`, `.publish/` or the bundled zip staged.

## Notes / follow-ups

- The macOS app gates the usage-recording toggle behind a confirmation dialog; Windows applies it with the existing Save-changes flow instead. Worth aligning if you want the confirm step on both.
- Cannot exercise the running UI from the macOS host — the pages were verified by build, binding resolution and symbol checks only. A smoke pass on a Windows box is still worth doing before release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Usage dashboard (token totals, daily trends, per-model breakdown, recent sessions) with range/provider filtering and refresh.
  * Added agent model selection across chat and Telegram (including a dedicated `/model` command).
  * Added usage-recording enable/disable settings and surfaced the settings source.
  * Promoted Usage to main navigation and added a Settings entry.
* **Bug Fixes**
  * Improved stalled agent WebSocket handling with an idle timeout.
  * Prevented empty shell requests from executing; they now return an error.
  * Improved model updates to roll back cleanly on failure.
* **Documentation / Tests**
  * Updated Telegram command docs and added coverage for timezone-aware usage bucketing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->